### PR TITLE
Broken invariant when removing liquidity

### DIFF
--- a/contracts/UniswapV3Pair.sol
+++ b/contracts/UniswapV3Pair.sol
@@ -327,6 +327,8 @@ contract UniswapV3Pair is IUniswapV3Pair {
         // amount1Upper :> amount1Lower
         (int112 amount0Lower, int112 amount1Lower) = getValueAtPrice(TickMath.getPrice(tickLower), liquidityDelta);
         (int112 amount0Upper, int112 amount1Upper) = getValueAtPrice(TickMath.getPrice(tickUpper), liquidityDelta);
+        assert(amount0Lower > amount0Upper);
+        assert(amount1Upper > amount1Lower);
 
         // regardless of current price, when lower tick is crossed from left to right, amount0Lower should be added
         if (tickLower > TickMath.MIN_TICK) {

--- a/test/UniswapV3Pair.spec.ts
+++ b/test/UniswapV3Pair.spec.ts
@@ -108,6 +108,9 @@ describe('UniswapV3Pair', () => {
 
       expect(await token0.balanceOf(pair.address)).to.eq(initializeToken0Amount.add(10))
       expect(await token1.balanceOf(pair.address)).to.eq(initializeToken1Amount)
+
+      // // The same liquidity can also be removed
+      await pair.setPosition(lowerTick, upperTick, FeeVote.FeeVote0, -1 * liquidityDelta, OVERRIDES)
     })
 
     it('setPosition to the left of the current price', async () => {


### PR DESCRIPTION
I interpreted the below comment in the code as "amount0Lower is always by definition going to be larger than amount0Upper" (similarly for amount1). Is that correct? If so, removing liquidity seems to break this invariant.

```
// amount0Lower :> amount0Upper
// amount1Upper :> amount1Lower
```