### PR TITLE
put something in the seconds outside slot so the gas is more even between 0-1 and 1-0

### DIFF
--- a/contracts/libraries/Tick.sol
+++ b/contracts/libraries/Tick.sol
@@ -11,14 +11,12 @@ library Tick {
     struct Info {
         // the total position liquidity that references this tick
         uint128 liquidityGross;
-        // amount of liquidity added (subtracted) when tick is crossed from left to right (right to left),
-        // i.e. as the price goes up (down), for each fee vote
-        int128 liquidityDelta;
-        // stored in the secondsOutside slot so the slot is not set from 0 when the tick is first crossed
-        bool initialized;
         // seconds spent on the _other_ side of this tick (relative to the current tick)
         // only has relative meaning, not absolute — the value depends on when the tick is initialized
         uint32 secondsOutside;
+        // amount of liquidity added (subtracted) when tick is crossed from left to right (right to left),
+        // i.e. as the price goes up (down), for each fee vote
+        int128 liquidityDelta;
         // fee growth per unit of liquidity on the _other_ side of this tick (relative to the current tick)
         // only has relative meaning, not absolute — the value depends on when the tick is initialized
         uint256 feeGrowthOutside0X128;
@@ -119,7 +117,6 @@ library Tick {
                     info.feeGrowthOutside1X128 = feeGrowthGlobal1X128;
                     info.secondsOutside = blockTimestamp;
                 }
-                info.initialized = true;
             }
 
             info.liquidityGross = liquidityGrossAfter;

--- a/test/Tick.spec.ts
+++ b/test/Tick.spec.ts
@@ -89,7 +89,6 @@ describe('TickTest', () => {
       await tickTest.setTick(2, {
         feeGrowthOutside0X128: 2,
         feeGrowthOutside1X128: 3,
-        initialized: true,
         secondsOutside: 0,
         liquidityGross: 0,
         liquidityDelta: 0,
@@ -103,7 +102,6 @@ describe('TickTest', () => {
       await tickTest.setTick(-2, {
         feeGrowthOutside0X128: 2,
         feeGrowthOutside1X128: 3,
-        initialized: true,
         secondsOutside: 0,
         liquidityGross: 0,
         liquidityDelta: 0,
@@ -117,7 +115,6 @@ describe('TickTest', () => {
       await tickTest.setTick(-2, {
         feeGrowthOutside0X128: 2,
         feeGrowthOutside1X128: 3,
-        initialized: true,
         secondsOutside: 0,
         liquidityGross: 0,
         liquidityDelta: 0,
@@ -125,7 +122,6 @@ describe('TickTest', () => {
       await tickTest.setTick(2, {
         feeGrowthOutside0X128: 4,
         feeGrowthOutside1X128: 1,
-        initialized: true,
         secondsOutside: 0,
         liquidityGross: 0,
         liquidityDelta: 0,

--- a/test/__snapshots__/UniswapV3Factory.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Factory.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Factory #createPair gas 1`] = `4229126`;
+exports[`UniswapV3Factory #createPair gas 1`] = `4225103`;
 
-exports[`UniswapV3Factory factory bytecode size 1`] = `23876`;
+exports[`UniswapV3Factory factory bytecode size 1`] = `23856`;
 
-exports[`UniswapV3Factory pair bytecode size 1`] = `20276`;
+exports[`UniswapV3Factory pair bytecode size 1`] = `20256`;

--- a/test/__snapshots__/UniswapV3Pair.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Pair.spec.ts.snap
@@ -1,71 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Pair gas #burn above current price burn entire position after some time passes 1`] = `64593`;
+exports[`UniswapV3Pair gas #burn above current price burn entire position after some time passes 1`] = `65434`;
 
-exports[`UniswapV3Pair gas #burn above current price burn when only position using ticks 1`] = `64593`;
+exports[`UniswapV3Pair gas #burn above current price burn when only position using ticks 1`] = `65434`;
 
-exports[`UniswapV3Pair gas #burn above current price entire position burn but other positions are using the ticks 1`] = `85022`;
+exports[`UniswapV3Pair gas #burn above current price entire position burn but other positions are using the ticks 1`] = `93438`;
 
-exports[`UniswapV3Pair gas #burn above current price partial position burn 1`] = `98395`;
+exports[`UniswapV3Pair gas #burn above current price partial position burn 1`] = `106811`;
 
-exports[`UniswapV3Pair gas #burn around current price burn entire position after some time passes 1`] = `83784`;
+exports[`UniswapV3Pair gas #burn around current price burn entire position after some time passes 1`] = `84625`;
 
-exports[`UniswapV3Pair gas #burn around current price burn when only position using ticks 1`] = `83784`;
+exports[`UniswapV3Pair gas #burn around current price burn when only position using ticks 1`] = `84625`;
 
-exports[`UniswapV3Pair gas #burn around current price entire position burn but other positions are using the ticks 1`] = `110803`;
+exports[`UniswapV3Pair gas #burn around current price entire position burn but other positions are using the ticks 1`] = `119219`;
 
-exports[`UniswapV3Pair gas #burn around current price partial position burn 1`] = `124176`;
+exports[`UniswapV3Pair gas #burn around current price partial position burn 1`] = `132592`;
 
-exports[`UniswapV3Pair gas #burn below current price burn entire position after some time passes 1`] = `73236`;
+exports[`UniswapV3Pair gas #burn below current price burn entire position after some time passes 1`] = `74077`;
 
-exports[`UniswapV3Pair gas #burn below current price burn when only position using ticks 1`] = `73236`;
+exports[`UniswapV3Pair gas #burn below current price burn when only position using ticks 1`] = `74077`;
 
-exports[`UniswapV3Pair gas #burn below current price entire position burn but other positions are using the ticks 1`] = `85508`;
+exports[`UniswapV3Pair gas #burn below current price entire position burn but other positions are using the ticks 1`] = `93924`;
 
-exports[`UniswapV3Pair gas #burn below current price partial position burn 1`] = `98881`;
+exports[`UniswapV3Pair gas #burn below current price partial position burn 1`] = `107297`;
 
-exports[`UniswapV3Pair gas #mint above current price add to position after some time passes 1`] = `119320`;
+exports[`UniswapV3Pair gas #mint above current price add to position after some time passes 1`] = `127736`;
 
-exports[`UniswapV3Pair gas #mint above current price add to position existing 1`] = `119320`;
+exports[`UniswapV3Pair gas #mint above current price add to position existing 1`] = `127736`;
 
-exports[`UniswapV3Pair gas #mint above current price new position mint first in range 1`] = `229280`;
+exports[`UniswapV3Pair gas #mint above current price new position mint first in range 1`] = `226022`;
 
-exports[`UniswapV3Pair gas #mint above current price second position in same range 1`] = `134320`;
+exports[`UniswapV3Pair gas #mint above current price second position in same range 1`] = `142736`;
 
-exports[`UniswapV3Pair gas #mint around current price add to position after some time passes 1`] = `161228`;
+exports[`UniswapV3Pair gas #mint around current price add to position after some time passes 1`] = `169644`;
 
-exports[`UniswapV3Pair gas #mint around current price add to position existing 1`] = `161228`;
+exports[`UniswapV3Pair gas #mint around current price add to position existing 1`] = `169644`;
 
-exports[`UniswapV3Pair gas #mint around current price new position mint first in range 1`] = `332062`;
+exports[`UniswapV3Pair gas #mint around current price new position mint first in range 1`] = `328807`;
 
-exports[`UniswapV3Pair gas #mint around current price second position in same range 1`] = `176228`;
+exports[`UniswapV3Pair gas #mint around current price second position in same range 1`] = `184644`;
 
-exports[`UniswapV3Pair gas #mint below current price add to position after some time passes 1`] = `119827`;
+exports[`UniswapV3Pair gas #mint below current price add to position after some time passes 1`] = `128243`;
 
-exports[`UniswapV3Pair gas #mint below current price add to position existing 1`] = `119827`;
+exports[`UniswapV3Pair gas #mint below current price add to position existing 1`] = `128243`;
 
-exports[`UniswapV3Pair gas #mint below current price new position mint first in range 1`] = `313135`;
+exports[`UniswapV3Pair gas #mint below current price new position mint first in range 1`] = `309883`;
 
-exports[`UniswapV3Pair gas #mint below current price second position in same range 1`] = `134827`;
+exports[`UniswapV3Pair gas #mint below current price second position in same range 1`] = `143243`;
 
 exports[`UniswapV3Pair gas #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `106812`;
 
 exports[`UniswapV3Pair gas #swapExact0For1 first swap in block with no tick movement 1`] = `98241`;
 
-exports[`UniswapV3Pair gas #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `124529`;
+exports[`UniswapV3Pair gas #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `124518`;
 
-exports[`UniswapV3Pair gas #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `153931`;
+exports[`UniswapV3Pair gas #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `153887`;
 
 exports[`UniswapV3Pair gas #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `120187`;
 
-exports[`UniswapV3Pair gas #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `153931`;
+exports[`UniswapV3Pair gas #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `153887`;
 
-exports[`UniswapV3Pair gas #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `214089`;
+exports[`UniswapV3Pair gas #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `214045`;
 
 exports[`UniswapV3Pair gas #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `106812`;
 
 exports[`UniswapV3Pair gas #swapExact0For1 second swap in block with no tick movement 1`] = `98340`;
 
-exports[`UniswapV3Pair gas #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `116273`;
+exports[`UniswapV3Pair gas #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `116262`;
 
-exports[`UniswapV3Pair gas #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `145645`;
+exports[`UniswapV3Pair gas #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `145601`;


### PR DESCRIPTION
when you cross 0-1 for the first time after a position is minted in the same block, seconds outside can be set to 0 which leads to a gas refund which makes our gas tests misleading since this is going to be pretty rare

this makes it so the change to seconds outside on tick crossing is not a refund