### PR TITLE
manually strip the revert reasons

### DIFF
--- a/contracts/UniswapV3Factory.sol
+++ b/contracts/UniswapV3Factory.sol
@@ -30,12 +30,12 @@ contract UniswapV3Factory is IUniswapV3Factory, UniswapV3PairDeployer, NoDelegat
         address tokenB,
         uint24 fee
     ) external override noDelegateCall returns (address pair) {
-        require(tokenA != tokenB, 'A=B');
+        require(tokenA != tokenB);
         (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
-        require(token0 != address(0), 'A=0');
+        require(token0 != address(0));
         int24 tickSpacing = feeAmountTickSpacing[fee];
-        require(tickSpacing != 0, 'FNA');
-        require(getPair[token0][token1][fee] == address(0), 'PAE');
+        require(tickSpacing != 0);
+        require(getPair[token0][token1][fee] == address(0));
         pair = deploy(address(this), token0, token1, fee, tickSpacing);
         getPair[token0][token1][fee] = pair;
         // populate mapping in the reverse direction, deliberate choice to avoid the cost of comparing addresses
@@ -44,19 +44,19 @@ contract UniswapV3Factory is IUniswapV3Factory, UniswapV3PairDeployer, NoDelegat
     }
 
     function setOwner(address _owner) external override {
-        require(msg.sender == owner, 'OO');
+        require(msg.sender == owner);
         emit OwnerChanged(owner, _owner);
         owner = _owner;
     }
 
     function enableFeeAmount(uint24 fee, int24 tickSpacing) public override {
-        require(msg.sender == owner, 'OO');
-        require(fee < 1000000, 'FEE');
+        require(msg.sender == owner);
+        require(fee < 1000000);
         // tick spacing is capped at 16384 to prevent the situation where tickSpacing is so large that
         // TickBitmap#nextInitializedTickWithinOneWord overflows int24 container from a valid tick
         // 16384 ticks represents a >5x price change with ticks of 1 bips
-        require(tickSpacing > 0 && tickSpacing < 16384, 'TS');
-        require(feeAmountTickSpacing[fee] == 0, 'FAI');
+        require(tickSpacing > 0 && tickSpacing < 16384);
+        require(feeAmountTickSpacing[fee] == 0);
 
         feeAmountTickSpacing[fee] = tickSpacing;
         emit FeeAmountEnabled(fee, tickSpacing);

--- a/contracts/UniswapV3Pair.sol
+++ b/contracts/UniswapV3Pair.sol
@@ -99,14 +99,14 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
     Oracle.Observation[65535] public override observations;
 
     modifier lock() {
-        require(slot0.unlocked, 'LOK');
+        require(slot0.unlocked);
         slot0.unlocked = false;
         _;
         slot0.unlocked = true;
     }
 
     modifier onlyFactoryOwner() {
-        require(msg.sender == IUniswapV3Factory(factory).owner(), 'OO');
+        require(msg.sender == IUniswapV3Factory(factory).owner());
         _;
     }
 
@@ -119,9 +119,9 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
     }
 
     function checkTicks(int24 tickLower, int24 tickUpper) private view {
-        require(tickLower < tickUpper, 'TLU');
-        require(tickLower >= minTick, 'TLM');
-        require(tickUpper <= maxTick, 'TUM');
+        require(tickLower < tickUpper);
+        require(tickLower >= minTick);
+        require(tickUpper <= maxTick);
     }
 
     // returns the block timestamp % 2**32
@@ -144,7 +144,7 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
 
     function secondsInside(int24 tickLower, int24 tickUpper) external view override noDelegateCall returns (uint32) {
         checkTicks(tickLower, tickUpper);
-        require(ticks[tickLower].liquidityGross > 0 && ticks[tickUpper].liquidityGross > 0, 'X');
+        require(ticks[tickLower].liquidityGross > 0 && ticks[tickUpper].liquidityGross > 0);
         return secondsOutside.secondsInside(tickLower, tickUpper, slot0.tick, tickSpacing, _blockTimestamp());
     }
 
@@ -170,7 +170,7 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
     // locked to prevent this from being called before
     function increaseObservationCardinality(uint16 observationCardinalityTarget) external override noDelegateCall {
         Slot0 memory _slot0 = slot0;
-        require(_slot0.observationCardinality > 0, 'OC'); // pair must be initialized to call this function
+        require(_slot0.observationCardinality > 0); // pair must be initialized to call this function
         (slot0.observationCardinality, slot0.observationCardinalityTarget) = observations.grow(
             _slot0.observationIndex,
             _slot0.observationCardinality,
@@ -182,11 +182,11 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
 
     // not locked because it initializes unlocked
     function initialize(uint160 sqrtPriceX96) external override {
-        require(slot0.sqrtPriceX96 == 0, 'AI');
+        require(slot0.sqrtPriceX96 == 0);
 
         int24 tick = SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96);
-        require(tick >= minTick, 'MIN');
-        require(tick < maxTick, 'MAX');
+        require(tick >= minTick);
+        require(tick < maxTick);
 
         (uint16 cardinality, uint16 target) = observations.initialize(_blockTimestamp());
 
@@ -372,8 +372,8 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
             if (amount0 > 0) balance0Before = balance0();
             if (amount1 > 0) balance1Before = balance1();
             IUniswapV3MintCallback(msg.sender).uniswapV3MintCallback(amount0, amount1, data);
-            if (amount0 > 0) require(balance0Before.add(amount0) <= balance0(), 'M0');
-            if (amount1 > 0) require(balance1Before.add(amount1) <= balance1(), 'M1');
+            if (amount0 > 0) require(balance0Before.add(amount0) <= balance0());
+            if (amount1 > 0) require(balance1Before.add(amount1) <= balance1());
         }
 
         emit Mint(recipient, tickLower, tickUpper, msg.sender, amount, amount0, amount1);
@@ -482,12 +482,12 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
         uint160 sqrtPriceLimitX96,
         bytes calldata data
     ) external override noDelegateCall {
-        require(amountSpecified != 0, 'AS');
+        require(amountSpecified != 0);
 
         Slot0 memory _slot0 = slot0;
 
-        require(_slot0.unlocked, 'LOK');
-        require(zeroForOne ? sqrtPriceLimitX96 < _slot0.sqrtPriceX96 : sqrtPriceLimitX96 > _slot0.sqrtPriceX96, 'SPL');
+        require(_slot0.unlocked);
+        require(zeroForOne ? sqrtPriceLimitX96 < _slot0.sqrtPriceX96 : sqrtPriceLimitX96 > _slot0.sqrtPriceX96);
 
         slot0.unlocked = false;
 
@@ -545,7 +545,7 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
 
             // shift tick if we reached the next price target
             if (state.sqrtPriceX96 == step.sqrtPriceNextX96) {
-                require(zeroForOne ? step.tickNext > minTick : step.tickNext < maxTick, 'TN');
+                require(zeroForOne ? step.tickNext > minTick : step.tickNext < maxTick);
 
                 // if the tick is initialized, run the tick transition
                 if (step.initialized) {
@@ -609,7 +609,7 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
         zeroForOne
             ? IUniswapV3SwapCallback(msg.sender).uniswapV3SwapCallback(amountIn, amountOut, data)
             : IUniswapV3SwapCallback(msg.sender).uniswapV3SwapCallback(amountOut, amountIn, data);
-        require(balanceBefore.add(uint256(amountIn)) >= balanceOfToken(tokenIn), 'IIA');
+        require(balanceBefore.add(uint256(amountIn)) >= balanceOfToken(tokenIn));
 
         if (zeroForOne) emit Swap(msg.sender, recipient, amountIn, amountOut, state.sqrtPriceX96, state.tick);
         else emit Swap(msg.sender, recipient, amountOut, amountIn, state.sqrtPriceX96, state.tick);
@@ -624,7 +624,7 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
         bytes calldata data
     ) external override lock noDelegateCall {
         uint128 _liquidity = liquidity;
-        require(_liquidity > 0, 'L');
+        require(_liquidity > 0);
 
         uint256 fee0 = FullMath.mulDivRoundingUp(amount0, fee, 1e6);
         uint256 fee1 = FullMath.mulDivRoundingUp(amount1, fee, 1e6);
@@ -639,8 +639,8 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
         uint256 paid0 = balance0().sub(balance0Before);
         uint256 paid1 = balance1().sub(balance1Before);
 
-        require(paid0 >= fee0, 'F0');
-        require(paid1 >= fee1, 'F1');
+        require(paid0 >= fee0);
+        require(paid1 >= fee1);
 
         if (paid0 > 0) feeGrowthGlobal0X128 += FullMath.mulDiv(paid0, FixedPoint128.Q128, _liquidity);
         if (paid1 > 0) feeGrowthGlobal1X128 += FullMath.mulDiv(paid1, FixedPoint128.Q128, _liquidity);
@@ -649,7 +649,7 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
     }
 
     function setFeeProtocol(uint8 feeProtocol) external override onlyFactoryOwner {
-        require(feeProtocol == 0 || (feeProtocol <= 10 && feeProtocol >= 4), 'FP');
+        require(feeProtocol == 0 || (feeProtocol <= 10 && feeProtocol >= 4));
         emit FeeProtocolChanged(slot0.feeProtocol, feeProtocol);
         slot0.feeProtocol = feeProtocol;
     }

--- a/contracts/libraries/BitMath.sol
+++ b/contracts/libraries/BitMath.sol
@@ -11,7 +11,7 @@ library BitMath {
     /// @param x the value for which to compute the most significant bit, must be greater than 0
     /// @return r the index of the most significant bit
     function mostSignificantBit(uint256 x) internal pure returns (uint8 r) {
-        require(x > 0, 'MSB');
+        require(x > 0);
 
         if (x >= 0x100000000000000000000000000000000) {
             x >>= 128;
@@ -51,7 +51,7 @@ library BitMath {
     /// @param x the value for which to compute the least significant bit, must be greater than 0
     /// @return r the index of the least significant bit
     function leastSignificantBit(uint256 x) internal pure returns (uint8 r) {
-        require(x > 0, 'LSB');
+        require(x > 0);
 
         r = 255;
         if (x & type(uint128).max > 0) {

--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -32,7 +32,7 @@ library FullMath {
         if (x == 0 || (x * y) / x == y) return ((x * y) / d);
 
         (uint256 l, uint256 h) = fullMul(x, y);
-        require(h < d, 'FMD');
+        require(h < d);
 
         // subtract remainder
         uint256 mm = mulmod(x, y, d);

--- a/contracts/libraries/LiquidityMath.sol
+++ b/contracts/libraries/LiquidityMath.sol
@@ -5,17 +5,17 @@ pragma solidity >=0.5.0;
 library LiquidityMath {
     function addDelta(uint128 x, int128 y) internal pure returns (uint128 z) {
         if (y < 0) {
-            require((z = x - uint128(-y)) < x, 'LS');
+            require((z = x - uint128(-y)) < x);
         } else {
-            require((z = x + uint128(y)) >= x, 'LA');
+            require((z = x + uint128(y)) >= x);
         }
     }
 
     function subDelta(uint128 x, int128 y) internal pure returns (uint128 z) {
         if (y < 0) {
-            require((z = x + uint128(-y)) > x, 'LA');
+            require((z = x + uint128(-y)) > x);
         } else {
-            require((z = x - uint128(y)) <= x, 'LS');
+            require((z = x - uint128(y)) <= x);
         }
     }
 }

--- a/contracts/libraries/Oracle.sol
+++ b/contracts/libraries/Oracle.sol
@@ -153,7 +153,7 @@ library Oracle {
         }
 
         // ensure that the target is greater than the oldest observation (accounting for block timestamp overflow)
-        require(beforeOrAt.blockTimestamp <= target && (target <= time || beforeOrAt.blockTimestamp >= time), 'OLD');
+        require(beforeOrAt.blockTimestamp <= target && (target <= time || beforeOrAt.blockTimestamp >= time));
 
         // now, optimistically set before to the newest observation
         beforeOrAt = self[index];
@@ -186,7 +186,7 @@ library Oracle {
         uint128 liquidity,
         uint16 cardinality
     ) internal view returns (int56 tickCumulative, uint160 liquidityCumulative) {
-        require(cardinality > 0, 'I');
+        require(cardinality > 0);
         if (secondsAgo == 0) {
             // because cardinality is 0, the last observation is necessarily initialized
             Observation memory last = self[index];

--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -42,7 +42,7 @@ library Position {
 
         uint128 liquidityNext;
         if (liquidityDelta == 0) {
-            require(_self.liquidity > 0, 'NP'); // disallow pokes for 0 liquidity positions
+            require(_self.liquidity > 0); // disallow pokes for 0 liquidity positions
             liquidityNext = _self.liquidity;
         } else {
             liquidityNext = LiquidityMath.addDelta(_self.liquidity, liquidityDelta);

--- a/contracts/libraries/SafeCast.sol
+++ b/contracts/libraries/SafeCast.sol
@@ -4,15 +4,15 @@ pragma solidity >=0.5.0;
 // contains methods for safely casting between integer types
 library SafeCast {
     function toUint160(uint256 y) internal pure returns (uint160 z) {
-        require((z = uint160(y)) == y, 'DO');
+        require((z = uint160(y)) == y);
     }
 
     function toInt128(int256 y) internal pure returns (int128 z) {
-        require((z = int128(y)) == y, 'DO');
+        require((z = int128(y)) == y);
     }
 
     function toInt256(uint256 y) internal pure returns (int256 z) {
-        require(y < 2**255, 'DO');
+        require(y < 2**255);
         z = int256(y);
     }
 }

--- a/contracts/libraries/SafeMath.sol
+++ b/contracts/libraries/SafeMath.sol
@@ -28,7 +28,7 @@ library SafeMath {
      */
     function add(uint256 a, uint256 b) internal pure returns (uint256 c) {
         c = a + b;
-        require(c >= a, 'AO');
+        require(c >= a);
     }
 
     /**
@@ -42,7 +42,7 @@ library SafeMath {
      * - Subtraction cannot overflow.
      */
     function sub(uint256 a, uint256 b) internal pure returns (uint256 c) {
-        require(b <= a, 'SO');
+        require(b <= a);
         c = a - b;
     }
 
@@ -86,7 +86,7 @@ library SafeMath {
         }
 
         c = a * b;
-        require(c / a == b, 'MO');
+        require(c / a == b);
     }
 
     function addCapped(uint128 x, uint256 y) internal pure returns (uint128 z) {

--- a/contracts/libraries/SecondsOutside.sol
+++ b/contracts/libraries/SecondsOutside.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.5.0;
 // enables packing
 library SecondsOutside {
     function position(int24 tick, int24 tickSpacing) private pure returns (int24 wordPos, uint8 shift) {
-        require(tick % tickSpacing == 0, 'TS');
+        require(tick % tickSpacing == 0);
 
         int24 compressed = tick / tickSpacing;
 

--- a/contracts/libraries/SignedSafeMath.sol
+++ b/contracts/libraries/SignedSafeMath.sol
@@ -19,7 +19,7 @@ library SignedSafeMath {
      */
     function sub(int256 a, int256 b) internal pure returns (int256 c) {
         c = a - b;
-        require((b >= 0 && c <= a) || (b < 0 && c > a), 'SSO');
+        require((b >= 0 && c <= a) || (b < 0 && c > a));
     }
 
     /**
@@ -34,6 +34,6 @@ library SignedSafeMath {
      */
     function add(int256 a, int256 b) internal pure returns (int256 c) {
         c = a + b;
-        require((b >= 0 && c >= a) || (b < 0 && c < a), 'SAO');
+        require((b >= 0 && c >= a) || (b < 0 && c < a));
     }
 }

--- a/contracts/libraries/SqrtPriceMath.sol
+++ b/contracts/libraries/SqrtPriceMath.sol
@@ -38,7 +38,7 @@ library SqrtPriceMath {
         }
 
         uint256 denominator1 = add ? (numerator1 / sqrtPX96).add(amount) : (numerator1 / sqrtPX96).sub(amount);
-        require(denominator1 != 0, 'OUT');
+        require(denominator1 != 0);
 
         return SafeMath.divRoundingUp(numerator1, denominator1).toUint160();
     }
@@ -74,8 +74,8 @@ library SqrtPriceMath {
         uint256 amountIn,
         bool zeroForOne
     ) internal pure returns (uint160 sqrtQX96) {
-        require(sqrtPX96 > 0, 'P');
-        require(liquidity > 0, 'L');
+        require(sqrtPX96 > 0);
+        require(liquidity > 0);
 
         // round to make sure that we don't pass the target price
         return
@@ -90,8 +90,8 @@ library SqrtPriceMath {
         uint256 amountOut,
         bool zeroForOne
     ) internal pure returns (uint160 sqrtQX96) {
-        require(sqrtPX96 > 0, 'P');
-        require(liquidity > 0, 'L');
+        require(sqrtPX96 > 0);
+        require(liquidity > 0);
 
         // round to make sure that we pass the target price
         return

--- a/contracts/libraries/Tick.sol
+++ b/contracts/libraries/Tick.sol
@@ -87,7 +87,7 @@ library Tick {
         uint128 liquidityGrossBefore = info.liquidityGross;
         uint128 liquidityGrossAfter = LiquidityMath.addDelta(liquidityGrossBefore, liquidityDelta);
 
-        require(liquidityGrossAfter <= maxLiquidity, 'LO');
+        require(liquidityGrossAfter <= maxLiquidity);
 
         flipped = (liquidityGrossAfter == 0) != (liquidityGrossBefore == 0);
 

--- a/contracts/libraries/TickBitmap.sol
+++ b/contracts/libraries/TickBitmap.sol
@@ -20,7 +20,7 @@ library TickBitmap {
         int24 tick,
         int24 tickSpacing
     ) internal {
-        require(tick % tickSpacing == 0, 'TS'); // ensure that the tick is spaced
+        require(tick % tickSpacing == 0); // ensure that the tick is spaced
         (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
         uint256 mask = 1 << bitPos;
         self[wordPos] ^= mask;

--- a/contracts/libraries/TickMath.sol
+++ b/contracts/libraries/TickMath.sol
@@ -8,7 +8,7 @@ library TickMath {
     // Calculate sqrt(1.0001)^tick * 2^128.  Throw in case |tick| > max tick.
     function getRatioAtTick(int24 tick) internal pure returns (uint256 ratio) {
         uint256 absTick = tick < 0 ? uint24(-tick) : uint24(tick);
-        require(absTick <= MAX_TICK, 'T');
+        require(absTick <= MAX_TICK);
 
         ratio = absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
         if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;

--- a/contracts/libraries/TransferHelper.sol
+++ b/contracts/libraries/TransferHelper.sol
@@ -17,6 +17,6 @@ library TransferHelper {
         uint256 value
     ) internal {
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, value));
-        require(success && (data.length == 0 || abi.decode(data, (bool))), 'TF');
+        require(success && (data.length == 0 || abi.decode(data, (bool))));
     }
 }

--- a/contracts/test/ERC20.sol
+++ b/contracts/test/ERC20.sol
@@ -221,8 +221,8 @@ contract ERC20 is IERC20 {
         address recipient,
         uint256 amount
     ) internal virtual {
-        require(sender != address(0), 'ERC20: transfer from the zero address');
-        require(recipient != address(0), 'ERC20: transfer to the zero address');
+        require(sender != address(0));
+        require(recipient != address(0));
 
         _beforeTokenTransfer(sender, recipient, amount);
 
@@ -241,7 +241,7 @@ contract ERC20 is IERC20 {
      * - `to` cannot be the zero address.
      */
     function _mint(address account, uint256 amount) internal virtual {
-        require(account != address(0), 'ERC20: mint to the zero address');
+        require(account != address(0));
 
         _beforeTokenTransfer(address(0), account, amount);
 
@@ -262,7 +262,7 @@ contract ERC20 is IERC20 {
      * - `account` must have at least `amount` tokens.
      */
     function _burn(address account, uint256 amount) internal virtual {
-        require(account != address(0), 'ERC20: burn from the zero address');
+        require(account != address(0));
 
         _beforeTokenTransfer(account, address(0), amount);
 
@@ -289,8 +289,8 @@ contract ERC20 is IERC20 {
         address spender,
         uint256 amount
     ) internal virtual {
-        require(owner != address(0), 'ERC20: approve from the zero address');
-        require(spender != address(0), 'ERC20: approve to the zero address');
+        require(owner != address(0));
+        require(spender != address(0));
 
         _allowances[owner][spender] = amount;
         emit Approval(owner, spender, amount);

--- a/contracts/test/OracleTest.sol
+++ b/contracts/test/OracleTest.sol
@@ -23,7 +23,7 @@ contract OracleTest {
     }
 
     function initialize(InitializeParams calldata params) external {
-        require(cardinality == 0, 'already initialized');
+        require(cardinality == 0);
         time = params.time;
         tick = params.tick;
         liquidity = params.liquidity;

--- a/test/Oracle.spec.ts
+++ b/test/Oracle.spec.ts
@@ -297,7 +297,7 @@ describe('Oracle', () => {
 
       it('fails if an older observation does not exist', async () => {
         await oracle.initialize({ liquidity: 4, tick: 2, time: 5 })
-        await expect(oracle.scry(1)).to.be.revertedWith('OLD')
+        await expect(oracle.scry(1)).to.be.revertedWith('')
       })
 
       it('single observation at current time', async () => {
@@ -310,7 +310,7 @@ describe('Oracle', () => {
       it('single observation in past but not earlier than secondsAgo', async () => {
         await oracle.initialize({ liquidity: 4, tick: 2, time: 5 })
         await oracle.advanceTime(3)
-        await expect(oracle.scry(4)).to.be.revertedWith('OLD')
+        await expect(oracle.scry(4)).to.be.revertedWith('')
       })
 
       it('single observation in past at exactly seconds ago', async () => {
@@ -484,9 +484,9 @@ describe('Oracle', () => {
           expect(liquidityCumulative).to.eq(72)
         })
         it('older than oldest reverts', async () => {
-          await expect(oracle.scry(15)).to.be.revertedWith('OLD')
+          await expect(oracle.scry(15)).to.be.revertedWith('')
           await oracle.advanceTime(5)
-          await expect(oracle.scry(20)).to.be.revertedWith('OLD')
+          await expect(oracle.scry(20)).to.be.revertedWith('')
         })
         it('oldest observation', async () => {
           const { tickCumulative, liquidityCumulative } = await oracle.scry(14)

--- a/test/SecondsOutside.spec.ts
+++ b/test/SecondsOutside.spec.ts
@@ -21,7 +21,7 @@ describe('SecondsOutside', () => {
 
   describe('#initialize', () => {
     it('reverts if tick is not multiple of tickSpacing', async () => {
-      await expect(secondsOutside.initialize(1, 8, 4, TEST_PAIR_START_TIME)).to.be.revertedWith('TS')
+      await expect(secondsOutside.initialize(1, 8, 4, TEST_PAIR_START_TIME)).to.be.revertedWith('')
     })
     it('tick 0 at current tick', async () => {
       const tick = 0

--- a/test/SqrtPriceMath.spec.ts
+++ b/test/SqrtPriceMath.spec.ts
@@ -17,20 +17,20 @@ describe('SqrtPriceMath', () => {
     it('fails if price is zero', async () => {
       await expect(
         sqrtPriceMath.getNextSqrtPriceFromInput(0, 0, expandTo18Decimals(1).div(10), false)
-      ).to.be.revertedWith('P')
+      ).to.be.revertedWith('')
     })
 
     it('fails if liquidity is zero', async () => {
       await expect(
         sqrtPriceMath.getNextSqrtPriceFromInput(1, 0, expandTo18Decimals(1).div(10), true)
-      ).to.be.revertedWith('L')
+      ).to.be.revertedWith('')
     })
 
     it('fails if input amount overflows the price', async () => {
       const price = BigNumber.from(2).pow(160).sub(1)
       const liquidity = 1024
       const amountIn = 1024
-      await expect(sqrtPriceMath.getNextSqrtPriceFromInput(price, liquidity, amountIn, false)).to.be.revertedWith('DO')
+      await expect(sqrtPriceMath.getNextSqrtPriceFromInput(price, liquidity, amountIn, false)).to.be.revertedWith('')
     })
 
     it('any input amount cannot underflow the price', async () => {
@@ -116,31 +116,27 @@ describe('SqrtPriceMath', () => {
     it('fails if price is zero', async () => {
       await expect(
         sqrtPriceMath.getNextSqrtPriceFromOutput(0, 0, expandTo18Decimals(1).div(10), false)
-      ).to.be.revertedWith('P')
+      ).to.be.revertedWith('')
     })
 
     it('fails if liquidity is zero', async () => {
       await expect(
         sqrtPriceMath.getNextSqrtPriceFromOutput(1, 0, expandTo18Decimals(1).div(10), true)
-      ).to.be.revertedWith('L')
+      ).to.be.revertedWith('')
     })
 
     it('fails if output amount is exactly the virtual reserves of token0', async () => {
       const price = '20282409603651670423947251286016'
       const liquidity = 1024
       const amountOut = 4
-      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, false)).to.be.revertedWith(
-        'OUT'
-      )
+      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, false)).to.be.revertedWith('')
     })
 
     it('fails if output amount is greater than virtual reserves of token0', async () => {
       const price = '20282409603651670423947251286016'
       const liquidity = 1024
       const amountOut = 5
-      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, false)).to.be.revertedWith(
-        'SO'
-      )
+      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, false)).to.be.revertedWith('')
     })
 
     it('succeeds if output amount is exactly the virtual reserves of token1', async () => {
@@ -155,7 +151,7 @@ describe('SqrtPriceMath', () => {
       const price = '20282409603651670423947251286016'
       const liquidity = 1024
       const amountOut = 262145
-      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, true)).to.be.revertedWith('SO')
+      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, true)).to.be.revertedWith('')
     })
 
     it('puzzling echidna test', async () => {
@@ -201,13 +197,13 @@ describe('SqrtPriceMath', () => {
     it('reverts if amountOut is impossible in zero for one direction', async () => {
       await expect(
         sqrtPriceMath.getNextSqrtPriceFromOutput(encodePriceSqrt(1, 1), 1, constants.MaxUint256, true)
-      ).to.be.revertedWith('FMD')
+      ).to.be.revertedWith('')
     })
 
     it('reverts if amountOut is impossible in one for zero direction', async () => {
       await expect(
         sqrtPriceMath.getNextSqrtPriceFromOutput(encodePriceSqrt(1, 1), 1, constants.MaxUint256, false)
-      ).to.be.revertedWith('SO')
+      ).to.be.revertedWith('')
     })
 
     it('zeroForOne = true gas', async () => {

--- a/test/SqrtTickMath.spec.ts
+++ b/test/SqrtTickMath.spec.ts
@@ -17,11 +17,11 @@ describe('SqrtTickMath', () => {
 
   describe('#getSqrtRatioAtTick', () => {
     it('throws for too low', async () => {
-      await expect(sqrtTickMath.getSqrtRatioAtTick(MIN_TICK - 1)).to.be.revertedWith('T')
+      await expect(sqrtTickMath.getSqrtRatioAtTick(MIN_TICK - 1)).to.be.revertedWith('')
     })
 
     it('throws for too low', async () => {
-      await expect(sqrtTickMath.getSqrtRatioAtTick(MAX_TICK + 1)).to.be.revertedWith('T')
+      await expect(sqrtTickMath.getSqrtRatioAtTick(MAX_TICK + 1)).to.be.revertedWith('')
     })
 
     it('min tick', async () => {
@@ -53,13 +53,13 @@ describe('SqrtTickMath', () => {
 
   describe('#getTickAtSqrtRatio', () => {
     it('throws for too low', async () => {
-      await expect(sqrtTickMath.getTickAtSqrtRatio(BigNumber.from('4295128738').sub(1))).to.be.revertedWith('R')
+      await expect(sqrtTickMath.getTickAtSqrtRatio(BigNumber.from('4295128738').sub(1))).to.be.revertedWith('')
     })
 
     it('throws for too high', async () => {
       await expect(
         sqrtTickMath.getTickAtSqrtRatio(BigNumber.from('1461446703485210103287273052203988822378723970342').add(1))
-      ).to.be.revertedWith('R')
+      ).to.be.revertedWith('')
     })
 
     it('ratio of min tick', async () => {

--- a/test/TickMath.spec.ts
+++ b/test/TickMath.spec.ts
@@ -111,10 +111,10 @@ describe('TickMath', () => {
     })
 
     it('tick too small', async () => {
-      await expect(tickMathTest.getRatioAtTick(MIN_TICK - 1)).to.be.revertedWith('T')
+      await expect(tickMathTest.getRatioAtTick(MIN_TICK - 1)).to.be.revertedWith('')
     })
     it('tick too large', async () => {
-      await expect(tickMathTest.getRatioAtTick(MAX_TICK + 1)).to.be.revertedWith('T')
+      await expect(tickMathTest.getRatioAtTick(MAX_TICK + 1)).to.be.revertedWith('')
     })
 
     it('ratio at min tick boundary', async () => {
@@ -144,10 +144,10 @@ describe('TickMath', () => {
     it('ratio too large', async () => {
       await expect(
         tickMathTest.getTickAtRatio(BigNumber.from('6276865796315986613307619852238232712866172378830071145882'))
-      ).to.be.revertedWith('R')
+      ).to.be.revertedWith('')
     })
     it('ratio too small', async () => {
-      await expect(tickMathTest.getTickAtRatio(BigNumber.from('18447437462383981825').sub(1))).to.be.revertedWith('R')
+      await expect(tickMathTest.getTickAtRatio(BigNumber.from('18447437462383981825').sub(1))).to.be.revertedWith('')
     })
 
     it('ratio at min tick boundary', async () => {

--- a/test/UniswapV3Factory.spec.ts
+++ b/test/UniswapV3Factory.spec.ts
@@ -69,8 +69,8 @@ describe('UniswapV3Factory', () => {
       .to.emit(factory, 'PairCreated')
       .withArgs(TEST_ADDRESSES[0], TEST_ADDRESSES[1], feeAmount, tickSpacing, create2Address)
 
-    await expect(factory.createPair(tokens[0], tokens[1], feeAmount)).to.be.revertedWith('PAE')
-    await expect(factory.createPair(tokens[1], tokens[0], feeAmount)).to.be.revertedWith('PAE')
+    await expect(factory.createPair(tokens[0], tokens[1], feeAmount)).to.be.revertedWith('')
+    await expect(factory.createPair(tokens[1], tokens[0], feeAmount)).to.be.revertedWith('')
     expect(await factory.getPair(tokens[0], tokens[1], feeAmount), 'getPair in order').to.eq(create2Address)
     expect(await factory.getPair(tokens[1], tokens[0], feeAmount), 'getPair in reverse').to.eq(create2Address)
 
@@ -100,23 +100,19 @@ describe('UniswapV3Factory', () => {
     })
 
     it('fails if token a == token b', async () => {
-      await expect(factory.createPair(TEST_ADDRESSES[0], TEST_ADDRESSES[0], FeeAmount.LOW)).to.be.revertedWith('A=B')
+      await expect(factory.createPair(TEST_ADDRESSES[0], TEST_ADDRESSES[0], FeeAmount.LOW)).to.be.revertedWith('')
     })
 
     it('fails if token a is 0 or token b is 0', async () => {
-      await expect(factory.createPair(TEST_ADDRESSES[0], constants.AddressZero, FeeAmount.LOW)).to.be.revertedWith(
-        'A=0'
-      )
-      await expect(factory.createPair(constants.AddressZero, TEST_ADDRESSES[0], FeeAmount.LOW)).to.be.revertedWith(
-        'A=0'
-      )
+      await expect(factory.createPair(TEST_ADDRESSES[0], constants.AddressZero, FeeAmount.LOW)).to.be.revertedWith('')
+      await expect(factory.createPair(constants.AddressZero, TEST_ADDRESSES[0], FeeAmount.LOW)).to.be.revertedWith('')
       await expect(factory.createPair(constants.AddressZero, constants.AddressZero, FeeAmount.LOW)).to.be.revertedWith(
-        'A=B'
+        ''
       )
     })
 
     it('fails if fee amount is not enabled', async () => {
-      await expect(factory.createPair(TEST_ADDRESSES[0], TEST_ADDRESSES[1], 250)).to.be.revertedWith('FNA')
+      await expect(factory.createPair(TEST_ADDRESSES[0], TEST_ADDRESSES[1], 250)).to.be.revertedWith('')
     })
 
     it('gas', async () => {
@@ -126,7 +122,7 @@ describe('UniswapV3Factory', () => {
 
   describe('#setOwner', () => {
     it('fails if caller is not owner', async () => {
-      await expect(factory.connect(other).setOwner(wallet.address)).to.be.revertedWith('OO')
+      await expect(factory.connect(other).setOwner(wallet.address)).to.be.revertedWith('')
     })
 
     it('updates owner', async () => {
@@ -142,26 +138,26 @@ describe('UniswapV3Factory', () => {
 
     it('cannot be called by original owner', async () => {
       await factory.setOwner(other.address)
-      await expect(factory.setOwner(wallet.address)).to.be.revertedWith('OO')
+      await expect(factory.setOwner(wallet.address)).to.be.revertedWith('')
     })
   })
 
   describe('#enableFeeAmount', () => {
     it('fails if caller is not owner', async () => {
-      await expect(factory.connect(other).enableFeeAmount(100, 2)).to.be.revertedWith('OO')
+      await expect(factory.connect(other).enableFeeAmount(100, 2)).to.be.revertedWith('')
     })
     it('fails if fee is too great', async () => {
-      await expect(factory.enableFeeAmount(1000000, 10)).to.be.revertedWith('FEE')
+      await expect(factory.enableFeeAmount(1000000, 10)).to.be.revertedWith('')
     })
     it('fails if tick spacing is too small', async () => {
-      await expect(factory.enableFeeAmount(500, 0)).to.be.revertedWith('TS')
+      await expect(factory.enableFeeAmount(500, 0)).to.be.revertedWith('')
     })
     it('fails if tick spacing is too large', async () => {
-      await expect(factory.enableFeeAmount(500, 16834)).to.be.revertedWith('TS')
+      await expect(factory.enableFeeAmount(500, 16834)).to.be.revertedWith('')
     })
     it('fails if already initialized', async () => {
       await factory.enableFeeAmount(100, 5)
-      await expect(factory.enableFeeAmount(100, 10)).to.be.revertedWith('FAI')
+      await expect(factory.enableFeeAmount(100, 10)).to.be.revertedWith('')
     })
     it('sets the fee amount in the mapping', async () => {
       await factory.enableFeeAmount(100, 5)

--- a/test/UniswapV3Pair.spec.ts
+++ b/test/UniswapV3Pair.spec.ts
@@ -110,13 +110,13 @@ describe('UniswapV3Pair', () => {
   describe('#initialize', () => {
     it('fails if already initialized', async () => {
       await pair.initialize(encodePriceSqrt(1, 1))
-      await expect(pair.initialize(encodePriceSqrt(1, 1))).to.be.revertedWith('AI')
+      await expect(pair.initialize(encodePriceSqrt(1, 1))).to.be.revertedWith('')
     })
     it('fails if starting price is too low', async () => {
-      await expect(pair.initialize(1)).to.be.revertedWith('R')
+      await expect(pair.initialize(1)).to.be.revertedWith('')
     })
     it('fails if starting price is too high', async () => {
-      await expect(pair.initialize(BigNumber.from(2).pow(160).sub(1))).to.be.revertedWith('R')
+      await expect(pair.initialize(BigNumber.from(2).pow(160).sub(1))).to.be.revertedWith('')
     })
     it('fails if starting price is too low or high', async () => {
       const minTick = await pair.minTick()
@@ -126,8 +126,8 @@ describe('UniswapV3Pair', () => {
       const badMinPrice = (await sqrtTickMath.getSqrtRatioAtTick(minTick)).sub(1)
       const badMaxPrice = await sqrtTickMath.getSqrtRatioAtTick(maxTick)
 
-      await expect(pair.initialize(badMinPrice)).to.be.revertedWith('MIN')
-      await expect(pair.initialize(badMaxPrice)).to.be.revertedWith('MAX')
+      await expect(pair.initialize(badMinPrice)).to.be.revertedWith('')
+      await expect(pair.initialize(badMaxPrice)).to.be.revertedWith('')
     })
     it('sets initial variables', async () => {
       const price = encodePriceSqrt(1, 2)
@@ -155,7 +155,7 @@ describe('UniswapV3Pair', () => {
 
   describe('#increaseObservationCardinality', () => {
     it('can only be called after initialize', async () => {
-      await expect(pair.increaseObservationCardinality(2)).to.be.revertedWith('OC')
+      await expect(pair.increaseObservationCardinality(2)).to.be.revertedWith('')
     })
     it('emits an event', async () => {
       await pair.initialize(encodePriceSqrt(1, 1))
@@ -182,7 +182,7 @@ describe('UniswapV3Pair', () => {
 
   describe('#mint', () => {
     it('fails if not initialized', async () => {
-      await expect(mint(wallet.address, -tickSpacing, tickSpacing, 0)).to.be.revertedWith('LOK')
+      await expect(mint(wallet.address, -tickSpacing, tickSpacing, 0)).to.be.revertedWith('')
     })
     describe('after initialization', () => {
       beforeEach('initialize the pair at price of 10:1', async () => {
@@ -192,22 +192,22 @@ describe('UniswapV3Pair', () => {
 
       describe('failure cases', () => {
         it('fails if tickLower greater than tickUpper', async () => {
-          await expect(mint(wallet.address, 1, 0, 1)).to.be.revertedWith('TLU')
+          await expect(mint(wallet.address, 1, 0, 1)).to.be.revertedWith('')
         })
         it('fails if tickLower less than min tick', async () => {
-          await expect(mint(wallet.address, minTick - 1, 0, 1)).to.be.revertedWith('TLM')
+          await expect(mint(wallet.address, minTick - 1, 0, 1)).to.be.revertedWith('')
         })
         it('fails if tickUpper greater than max tick', async () => {
-          await expect(mint(wallet.address, 0, maxTick + 1, 1)).to.be.revertedWith('TUM')
+          await expect(mint(wallet.address, 0, maxTick + 1, 1)).to.be.revertedWith('')
         })
         it('fails if amount exceeds the max', async () => {
           const maxLiquidityGross = await pair.maxLiquidityPerTick()
           await expect(
             mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross.add(1))
-          ).to.be.revertedWith('LO')
+          ).to.be.revertedWith('')
           await expect(
             mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross)
-          ).to.not.be.revertedWith('LO')
+          ).to.not.be.revertedWith('')
         })
         it('fails if total amount at tick exceeds the max', async () => {
           await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 1000)
@@ -215,16 +215,16 @@ describe('UniswapV3Pair', () => {
           const maxLiquidityGross = await pair.maxLiquidityPerTick()
           await expect(
             mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross.sub(1000).add(1))
-          ).to.be.revertedWith('LO')
+          ).to.be.revertedWith('')
           await expect(
             mint(wallet.address, minTick + tickSpacing * 2, maxTick - tickSpacing, maxLiquidityGross.sub(1000).add(1))
-          ).to.be.revertedWith('LO')
+          ).to.be.revertedWith('')
           await expect(
             mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing * 2, maxLiquidityGross.sub(1000).add(1))
-          ).to.be.revertedWith('LO')
+          ).to.be.revertedWith('')
           await expect(
             mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross.sub(1000))
-          ).to.not.be.revertedWith('LO')
+          ).to.not.be.revertedWith('')
         })
       })
 
@@ -496,7 +496,7 @@ describe('UniswapV3Pair', () => {
         await swapExact0For1(expandTo18Decimals(1).div(10), wallet.address)
         await swapExact1For0(expandTo18Decimals(1).div(100), wallet.address)
 
-        await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 0)).to.be.revertedWith('NP')
+        await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 0)).to.be.revertedWith('')
 
         await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 1)
         let {
@@ -734,7 +734,7 @@ describe('UniswapV3Pair', () => {
       const lowerTick = -tickSpacing
       const upperTick = tickSpacing
       await mint(wallet.address, lowerTick, upperTick, expandTo18Decimals(1000))
-      await expect(pair.burn(wallet.address, lowerTick, upperTick, expandTo18Decimals(1001))).to.be.revertedWith('LS')
+      await expect(pair.burn(wallet.address, lowerTick, upperTick, expandTo18Decimals(1001))).to.be.revertedWith('')
     })
 
     it('collect fees within the current price after swap', async () => {
@@ -932,12 +932,12 @@ describe('UniswapV3Pair', () => {
     })
 
     it('cannot be changed out of bounds', async () => {
-      await expect(pair.setFeeProtocol(3)).to.be.revertedWith('FP')
-      await expect(pair.setFeeProtocol(11)).to.be.revertedWith('FP')
+      await expect(pair.setFeeProtocol(3)).to.be.revertedWith('')
+      await expect(pair.setFeeProtocol(11)).to.be.revertedWith('')
     })
 
     it('cannot be changed by addresses that are not owner', async () => {
-      await expect(pair.connect(other).setFeeProtocol(6)).to.be.revertedWith('OO')
+      await expect(pair.connect(other).setFeeProtocol(6)).to.be.revertedWith('')
     })
 
     async function swapAndGetFeesOwed({
@@ -1171,8 +1171,8 @@ describe('UniswapV3Pair', () => {
           await pair.initialize(encodePriceSqrt(1, 1))
         })
         it('mint can only be called for multiples of 12', async () => {
-          await expect(mint(wallet.address, -6, 0, 1)).to.be.revertedWith('TS')
-          await expect(mint(wallet.address, 0, 6, 1)).to.be.revertedWith('TS')
+          await expect(mint(wallet.address, -6, 0, 1)).to.be.revertedWith('')
+          await expect(mint(wallet.address, 0, 6, 1)).to.be.revertedWith('')
         })
         it('mint can be called with multiples of 12', async () => {
           await mint(wallet.address, 12, 24, 1)
@@ -1252,15 +1252,15 @@ describe('UniswapV3Pair', () => {
 
   describe('#flash', () => {
     it('fails if not initialized', async () => {
-      await expect(flash(100, 200, other.address)).to.be.revertedWith('LOK')
-      await expect(flash(100, 0, other.address)).to.be.revertedWith('LOK')
-      await expect(flash(0, 200, other.address)).to.be.revertedWith('LOK')
+      await expect(flash(100, 200, other.address)).to.be.revertedWith('')
+      await expect(flash(100, 0, other.address)).to.be.revertedWith('')
+      await expect(flash(0, 200, other.address)).to.be.revertedWith('')
     })
     it('fails if no liquidity', async () => {
       await pair.initialize(encodePriceSqrt(1, 1))
-      await expect(flash(100, 200, other.address)).to.be.revertedWith('L')
-      await expect(flash(100, 0, other.address)).to.be.revertedWith('L')
-      await expect(flash(0, 200, other.address)).to.be.revertedWith('L')
+      await expect(flash(100, 200, other.address)).to.be.revertedWith('')
+      await expect(flash(100, 0, other.address)).to.be.revertedWith('')
+      await expect(flash(0, 200, other.address)).to.be.revertedWith('')
     })
     describe('after liquidity added', () => {
       let balance0: BigNumber
@@ -1329,8 +1329,8 @@ describe('UniswapV3Pair', () => {
         await expect(flash(0, 1000, other.address, 0, 999)).to.be.revertedWith('')
       })
       it('fails if underpays either token', async () => {
-        await expect(flash(1000, 0, other.address, 1002, 0)).to.be.revertedWith('F0')
-        await expect(flash(0, 1000, other.address, 0, 1002)).to.be.revertedWith('F1')
+        await expect(flash(1000, 0, other.address, 1002, 0)).to.be.revertedWith('')
+        await expect(flash(0, 1000, other.address, 0, 1002)).to.be.revertedWith('')
       })
       it('allows donating token0', async () => {
         await expect(flash(0, 0, constants.AddressZero, 567, 0))

--- a/test/__snapshots__/UniswapV3Factory.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Factory.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Factory #createPair gas 1`] = `4708025`;
+exports[`UniswapV3Factory #createPair gas 1`] = `4249159`;
 
-exports[`UniswapV3Factory factory bytecode size 1`] = `25890`;
+exports[`UniswapV3Factory factory bytecode size 1`] = `23193`;
 
-exports[`UniswapV3Factory pair bytecode size 1`] = `22877`;
+exports[`UniswapV3Factory pair bytecode size 1`] = `20591`;

--- a/test/__snapshots__/UniswapV3Pair.gas.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Pair.gas.spec.ts.snap
@@ -4,25 +4,25 @@ exports[`UniswapV3Pair gas tests fee is off #burn above current price burn entir
 
 exports[`UniswapV3Pair gas tests fee is off #burn above current price burn when only position using ticks 1`] = `56673`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn above current price entire position burn but other positions are using the ticks 1`] = `76652`;
+exports[`UniswapV3Pair gas tests fee is off #burn above current price entire position burn but other positions are using the ticks 1`] = `76651`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn above current price partial position burn 1`] = `90025`;
+exports[`UniswapV3Pair gas tests fee is off #burn above current price partial position burn 1`] = `90024`;
 
 exports[`UniswapV3Pair gas tests fee is off #burn around current price burn entire position after some time passes 1`] = `83354`;
 
 exports[`UniswapV3Pair gas tests fee is off #burn around current price burn when only position using ticks 1`] = `80016`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn around current price entire position burn but other positions are using the ticks 1`] = `104535`;
+exports[`UniswapV3Pair gas tests fee is off #burn around current price entire position burn but other positions are using the ticks 1`] = `104534`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn around current price partial position burn 1`] = `117908`;
+exports[`UniswapV3Pair gas tests fee is off #burn around current price partial position burn 1`] = `117907`;
 
 exports[`UniswapV3Pair gas tests fee is off #burn below current price burn entire position after some time passes 1`] = `69495`;
 
 exports[`UniswapV3Pair gas tests fee is off #burn below current price burn when only position using ticks 1`] = `69495`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn below current price entire position burn but other positions are using the ticks 1`] = `77290`;
+exports[`UniswapV3Pair gas tests fee is off #burn below current price entire position burn but other positions are using the ticks 1`] = `77289`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn below current price partial position burn 1`] = `90663`;
+exports[`UniswapV3Pair gas tests fee is off #burn below current price partial position burn 1`] = `90662`;
 
 exports[`UniswapV3Pair gas tests fee is off #collect close to worst case 1`] = `41817`;
 
@@ -78,25 +78,25 @@ exports[`UniswapV3Pair gas tests fee is on #burn above current price burn entire
 
 exports[`UniswapV3Pair gas tests fee is on #burn above current price burn when only position using ticks 1`] = `56673`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn above current price entire position burn but other positions are using the ticks 1`] = `76652`;
+exports[`UniswapV3Pair gas tests fee is on #burn above current price entire position burn but other positions are using the ticks 1`] = `76651`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn above current price partial position burn 1`] = `90025`;
+exports[`UniswapV3Pair gas tests fee is on #burn above current price partial position burn 1`] = `90024`;
 
 exports[`UniswapV3Pair gas tests fee is on #burn around current price burn entire position after some time passes 1`] = `83354`;
 
 exports[`UniswapV3Pair gas tests fee is on #burn around current price burn when only position using ticks 1`] = `80016`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn around current price entire position burn but other positions are using the ticks 1`] = `104535`;
+exports[`UniswapV3Pair gas tests fee is on #burn around current price entire position burn but other positions are using the ticks 1`] = `104534`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn around current price partial position burn 1`] = `117908`;
+exports[`UniswapV3Pair gas tests fee is on #burn around current price partial position burn 1`] = `117907`;
 
 exports[`UniswapV3Pair gas tests fee is on #burn below current price burn entire position after some time passes 1`] = `69495`;
 
 exports[`UniswapV3Pair gas tests fee is on #burn below current price burn when only position using ticks 1`] = `69495`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn below current price entire position burn but other positions are using the ticks 1`] = `77290`;
+exports[`UniswapV3Pair gas tests fee is on #burn below current price entire position burn but other positions are using the ticks 1`] = `77289`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn below current price partial position burn 1`] = `90663`;
+exports[`UniswapV3Pair gas tests fee is on #burn below current price partial position burn 1`] = `90662`;
 
 exports[`UniswapV3Pair gas tests fee is on #collect close to worst case 1`] = `41817`;
 

--- a/test/__snapshots__/UniswapV3Pair.swaps.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Pair.swaps.spec.ts.snap
@@ -133,7 +133,7 @@ Object {
   "pairBalance0": "1",
   "pairBalance1": "26087635650665564424699143612505016738",
   "pairPriceBefore": "1.7014e+38",
-  "swapError": "VM Exception while processing transaction: revert TN",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 880340,
 }
 `;
@@ -143,7 +143,7 @@ Object {
   "pairBalance0": "1",
   "pairBalance1": "26087635650665564424699143612505016738",
   "pairPriceBefore": "1.7014e+38",
-  "swapError": "VM Exception while processing transaction: revert TN",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 880340,
 }
 `;
@@ -153,7 +153,7 @@ Object {
   "pairBalance0": "1",
   "pairBalance1": "26087635650665564424699143612505016738",
   "pairPriceBefore": "1.7014e+38",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 880340,
 }
 `;
@@ -163,7 +163,7 @@ Object {
   "pairBalance0": "1",
   "pairBalance1": "26087635650665564424699143612505016738",
   "pairPriceBefore": "1.7014e+38",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 880340,
 }
 `;
@@ -237,7 +237,7 @@ Object {
   "pairBalance0": "26037782196502120275425782622539039026",
   "pairBalance1": "1",
   "pairPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "swapError": "VM Exception while processing transaction: revert TN",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": -880303,
 }
 `;
@@ -247,7 +247,7 @@ Object {
   "pairBalance0": "26037782196502120275425782622539039026",
   "pairBalance1": "1",
   "pairPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "swapError": "VM Exception while processing transaction: revert TN",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": -880303,
 }
 `;
@@ -257,7 +257,7 @@ Object {
   "pairBalance0": "26037782196502120275425782622539039026",
   "pairBalance1": "1",
   "pairPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": -880303,
 }
 `;
@@ -267,7 +267,7 @@ Object {
   "pairBalance0": "26037782196502120275425782622539039026",
   "pairBalance1": "1",
   "pairPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": -880303,
 }
 `;
@@ -453,7 +453,7 @@ Object {
   "pairBalance0": "2000000000000000000",
   "pairBalance1": "2000000000000000000",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -495,7 +495,7 @@ Object {
   "pairBalance0": "2000000000000000000",
   "pairBalance1": "2000000000000000000",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -633,7 +633,7 @@ Object {
   "pairBalance0": "2000000000000000000",
   "pairBalance1": "2000000000000000000",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -675,7 +675,7 @@ Object {
   "pairBalance0": "2000000000000000000",
   "pairBalance1": "2000000000000000000",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -733,7 +733,7 @@ Object {
   "pairBalance0": "1199580111974806",
   "pairBalance1": "1199580111974806",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -743,7 +743,7 @@ Object {
   "pairBalance0": "1199580111974806",
   "pairBalance1": "1199580111974806",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -769,7 +769,7 @@ Object {
   "pairBalance0": "1199580111974806",
   "pairBalance1": "1199580111974806",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -795,7 +795,7 @@ Object {
   "pairBalance0": "1199580111974806",
   "pairBalance1": "1199580111974806",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -821,7 +821,7 @@ Object {
   "pairBalance0": "1199580111974806",
   "pairBalance1": "1199580111974806",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -831,7 +831,7 @@ Object {
   "pairBalance0": "1199580111974806",
   "pairBalance1": "1199580111974806",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -969,7 +969,7 @@ Object {
   "pairBalance0": "11505743598341114571255423385623647",
   "pairBalance1": "11505743598341114571255423385506404",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1011,7 +1011,7 @@ Object {
   "pairBalance0": "11505743598341114571255423385623647",
   "pairBalance1": "11505743598341114571255423385506404",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1149,7 +1149,7 @@ Object {
   "pairBalance0": "1982081649422850916",
   "pairBalance1": "1994009290088178439",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1191,7 +1191,7 @@ Object {
   "pairBalance0": "1982081649422850916",
   "pairBalance1": "1994009290088178439",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1329,7 +1329,7 @@ Object {
   "pairBalance0": "2000000000000000000",
   "pairBalance1": "2000000000000000000",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1371,7 +1371,7 @@ Object {
   "pairBalance0": "2000000000000000000",
   "pairBalance1": "2000000000000000000",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1509,7 +1509,7 @@ Object {
   "pairBalance0": "3982081649422850916",
   "pairBalance1": "3994009290088178439",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1551,7 +1551,7 @@ Object {
   "pairBalance0": "3982081649422850916",
   "pairBalance1": "3994009290088178439",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1657,7 +1657,7 @@ Object {
   "pairBalance0": "6324555320336758664",
   "pairBalance1": "632455532033675867",
   "pairPriceBefore": "0.10000",
-  "swapError": "VM Exception while processing transaction: revert TN",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": -23028,
 }
 `;
@@ -1667,7 +1667,7 @@ Object {
   "pairBalance0": "6324555320336758664",
   "pairBalance1": "632455532033675867",
   "pairPriceBefore": "0.10000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": -23028,
 }
 `;
@@ -1677,7 +1677,7 @@ Object {
   "pairBalance0": "6324555320336758664",
   "pairBalance1": "632455532033675867",
   "pairPriceBefore": "0.10000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": -23028,
 }
 `;
@@ -1895,7 +1895,7 @@ Object {
   "pairBalance0": "632455532033675867",
   "pairBalance1": "6324555320336758664",
   "pairPriceBefore": "10.000",
-  "swapError": "VM Exception while processing transaction: revert TN",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 23027,
 }
 `;
@@ -1905,7 +1905,7 @@ Object {
   "pairBalance0": "632455532033675867",
   "pairBalance1": "6324555320336758664",
   "pairPriceBefore": "10.000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 23027,
 }
 `;
@@ -1915,7 +1915,7 @@ Object {
   "pairBalance0": "632455532033675867",
   "pairBalance1": "6324555320336758664",
   "pairPriceBefore": "10.000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 23027,
 }
 `;
@@ -1925,7 +1925,7 @@ Object {
   "pairBalance0": "1995041008271423675",
   "pairBalance1": "0",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1951,7 +1951,7 @@ Object {
   "pairBalance0": "1995041008271423675",
   "pairBalance1": "0",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1977,7 +1977,7 @@ Object {
   "pairBalance0": "1995041008271423675",
   "pairBalance1": "0",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -1987,7 +1987,7 @@ Object {
   "pairBalance0": "1995041008271423675",
   "pairBalance1": "0",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -2013,7 +2013,7 @@ Object {
   "pairBalance0": "1995041008271423675",
   "pairBalance1": "0",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -2055,7 +2055,7 @@ Object {
   "pairBalance0": "1995041008271423675",
   "pairBalance1": "0",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -2097,7 +2097,7 @@ Object {
   "pairBalance0": "0",
   "pairBalance1": "1995041008271423675",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -2123,7 +2123,7 @@ Object {
   "pairBalance0": "0",
   "pairBalance1": "1995041008271423675",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -2181,7 +2181,7 @@ Object {
   "pairBalance0": "0",
   "pairBalance1": "1995041008271423675",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -2191,7 +2191,7 @@ Object {
   "pairBalance0": "0",
   "pairBalance1": "1995041008271423675",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -2201,7 +2201,7 @@ Object {
   "pairBalance0": "0",
   "pairBalance1": "1995041008271423675",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert T",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;
@@ -2211,7 +2211,7 @@ Object {
   "pairBalance0": "0",
   "pairBalance1": "1995041008271423675",
   "pairPriceBefore": "1.0000",
-  "swapError": "VM Exception while processing transaction: revert SPL",
+  "swapError": "Transaction reverted without a reason",
   "tickBefore": 0,
 }
 `;


### PR DESCRIPTION
just to see if it's exactly the same as the strip revert strings setting. this is better if it is equivalent, since etherscan does not need to support it

diff is between this and 
```
exports[`UniswapV3Factory factory bytecode size 1`] = `23149`;
exports[`UniswapV3Factory pair bytecode size 1`] = `20547`;
```

looks like 54 more bytes are being used for something not being stripped

it also costs a bit more gas at runtime (~20 gas saved in other branch)