### PR TITLE
Changed target variable name in instances of conflicting definitions

### DIFF
--- a/contracts/libraries/Oracle.sol
+++ b/contracts/libraries/Oracle.sol
@@ -153,7 +153,10 @@ library Oracle {
         }
 
         // ensure that the touchpoint is greater than the oldest observation (accounting for block timestamp overflow)
-        require(beforeOrAt.blockTimestamp <= touchpoint && (touchpoint <= time || beforeOrAt.blockTimestamp >= time), 'OLD');
+        require(
+            beforeOrAt.blockTimestamp <= touchpoint && (touchpoint <= time || beforeOrAt.blockTimestamp >= time),
+            'OLD'
+        );
 
         // now, optimistically set before to the newest observation
         beforeOrAt = self[index];


### PR DESCRIPTION
variable `target` is used in two definitions:

target as in: The length of the oracle array, independent of population
and target as in: The desired time of an observation, or a counterfactual observation if a canonical one does not exist


Changed 'target' variable in instances of desired observation time to `touchpoint` - leaving `target` as length of oracle array independent of population