### PR TITLE
first pass of some revert reasons that are not useful

### DIFF
--- a/contracts/UniswapV3Factory.sol
+++ b/contracts/UniswapV3Factory.sol
@@ -30,12 +30,12 @@ contract UniswapV3Factory is IUniswapV3Factory, UniswapV3PairDeployer, NoDelegat
         address tokenB,
         uint24 fee
     ) external override noDelegateCall returns (address pair) {
-        require(tokenA != tokenB, 'A=B');
+        require(tokenA != tokenB);
         (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
-        require(token0 != address(0), 'A=0');
+        require(token0 != address(0));
         int24 tickSpacing = feeAmountTickSpacing[fee];
-        require(tickSpacing != 0, 'FNA');
-        require(getPair[token0][token1][fee] == address(0), 'PAE');
+        require(tickSpacing != 0);
+        require(getPair[token0][token1][fee] == address(0));
         pair = deploy(address(this), token0, token1, fee, tickSpacing);
         getPair[token0][token1][fee] = pair;
         // populate mapping in the reverse direction, deliberate choice to avoid the cost of comparing addresses
@@ -44,19 +44,19 @@ contract UniswapV3Factory is IUniswapV3Factory, UniswapV3PairDeployer, NoDelegat
     }
 
     function setOwner(address _owner) external override {
-        require(msg.sender == owner, 'OO');
+        require(msg.sender == owner);
         emit OwnerChanged(owner, _owner);
         owner = _owner;
     }
 
     function enableFeeAmount(uint24 fee, int24 tickSpacing) public override {
-        require(msg.sender == owner, 'OO');
-        require(fee < 1000000, 'FEE');
+        require(msg.sender == owner);
+        require(fee < 1000000);
         // tick spacing is capped at 16384 to prevent the situation where tickSpacing is so large that
         // TickBitmap#nextInitializedTickWithinOneWord overflows int24 container from a valid tick
         // 16384 ticks represents a >5x price change with ticks of 1 bips
-        require(tickSpacing > 0 && tickSpacing < 16384, 'TS');
-        require(feeAmountTickSpacing[fee] == 0, 'FAI');
+        require(tickSpacing > 0 && tickSpacing < 16384);
+        require(feeAmountTickSpacing[fee] == 0);
 
         feeAmountTickSpacing[fee] = tickSpacing;
         emit FeeAmountEnabled(fee, tickSpacing);

--- a/contracts/UniswapV3Pair.sol
+++ b/contracts/UniswapV3Pair.sol
@@ -106,7 +106,7 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
     }
 
     modifier onlyFactoryOwner() {
-        require(msg.sender == IUniswapV3Factory(factory).owner(), 'OO');
+        require(msg.sender == IUniswapV3Factory(factory).owner());
         _;
     }
 
@@ -649,7 +649,7 @@ contract UniswapV3Pair is IUniswapV3Pair, NoDelegateCall {
     }
 
     function setFeeProtocol(uint8 feeProtocol) external override onlyFactoryOwner {
-        require(feeProtocol == 0 || (feeProtocol <= 10 && feeProtocol >= 4), 'FP');
+        require(feeProtocol == 0 || (feeProtocol <= 10 && feeProtocol >= 4));
         emit FeeProtocolChanged(slot0.feeProtocol, feeProtocol);
         slot0.feeProtocol = feeProtocol;
     }

--- a/contracts/libraries/BitMath.sol
+++ b/contracts/libraries/BitMath.sol
@@ -11,7 +11,7 @@ library BitMath {
     /// @param x the value for which to compute the most significant bit, must be greater than 0
     /// @return r the index of the most significant bit
     function mostSignificantBit(uint256 x) internal pure returns (uint8 r) {
-        require(x > 0, 'MSB');
+        require(x > 0);
 
         if (x >= 0x100000000000000000000000000000000) {
             x >>= 128;
@@ -51,7 +51,7 @@ library BitMath {
     /// @param x the value for which to compute the least significant bit, must be greater than 0
     /// @return r the index of the least significant bit
     function leastSignificantBit(uint256 x) internal pure returns (uint8 r) {
-        require(x > 0, 'LSB');
+        require(x > 0);
 
         r = 255;
         if (x & type(uint128).max > 0) {

--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -32,7 +32,7 @@ library FullMath {
         if (x == 0 || (x * y) / x == y) return ((x * y) / d);
 
         (uint256 l, uint256 h) = fullMul(x, y);
-        require(h < d, 'FMD');
+        require(h < d);
 
         // subtract remainder
         uint256 mm = mulmod(x, y, d);

--- a/contracts/libraries/SafeCast.sol
+++ b/contracts/libraries/SafeCast.sol
@@ -4,15 +4,15 @@ pragma solidity >=0.5.0;
 // contains methods for safely casting between integer types
 library SafeCast {
     function toUint160(uint256 y) internal pure returns (uint160 z) {
-        require((z = uint160(y)) == y, 'DO');
+        require((z = uint160(y)) == y);
     }
 
     function toInt128(int256 y) internal pure returns (int128 z) {
-        require((z = int128(y)) == y, 'DO');
+        require((z = int128(y)) == y);
     }
 
     function toInt256(uint256 y) internal pure returns (int256 z) {
-        require(y < 2**255, 'DO');
+        require(y < 2**255);
         z = int256(y);
     }
 }

--- a/contracts/libraries/SafeMath.sol
+++ b/contracts/libraries/SafeMath.sol
@@ -28,7 +28,7 @@ library SafeMath {
      */
     function add(uint256 a, uint256 b) internal pure returns (uint256 c) {
         c = a + b;
-        require(c >= a, 'AO');
+        require(c >= a);
     }
 
     /**
@@ -42,7 +42,7 @@ library SafeMath {
      * - Subtraction cannot overflow.
      */
     function sub(uint256 a, uint256 b) internal pure returns (uint256 c) {
-        require(b <= a, 'SO');
+        require(b <= a);
         c = a - b;
     }
 
@@ -86,7 +86,7 @@ library SafeMath {
         }
 
         c = a * b;
-        require(c / a == b, 'MO');
+        require(c / a == b);
     }
 
     function addCapped(uint128 x, uint256 y) internal pure returns (uint128 z) {

--- a/contracts/libraries/SecondsOutside.sol
+++ b/contracts/libraries/SecondsOutside.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.5.0;
 // enables packing
 library SecondsOutside {
     function position(int24 tick, int24 tickSpacing) private pure returns (int24 wordPos, uint8 shift) {
-        require(tick % tickSpacing == 0, 'TS');
+        require(tick % tickSpacing == 0);
 
         int24 compressed = tick / tickSpacing;
 

--- a/contracts/libraries/SignedSafeMath.sol
+++ b/contracts/libraries/SignedSafeMath.sol
@@ -19,7 +19,7 @@ library SignedSafeMath {
      */
     function sub(int256 a, int256 b) internal pure returns (int256 c) {
         c = a - b;
-        require((b >= 0 && c <= a) || (b < 0 && c > a), 'SSO');
+        require((b >= 0 && c <= a) || (b < 0 && c > a));
     }
 
     /**
@@ -34,6 +34,6 @@ library SignedSafeMath {
      */
     function add(int256 a, int256 b) internal pure returns (int256 c) {
         c = a + b;
-        require((b >= 0 && c >= a) || (b < 0 && c < a), 'SAO');
+        require((b >= 0 && c >= a) || (b < 0 && c < a));
     }
 }

--- a/contracts/libraries/TickBitmap.sol
+++ b/contracts/libraries/TickBitmap.sol
@@ -20,7 +20,7 @@ library TickBitmap {
         int24 tick,
         int24 tickSpacing
     ) internal {
-        require(tick % tickSpacing == 0, 'TS'); // ensure that the tick is spaced
+        require(tick % tickSpacing == 0); // ensure that the tick is spaced
         (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
         uint256 mask = 1 << bitPos;
         self[wordPos] ^= mask;

--- a/test/BitMath.spec.ts
+++ b/test/BitMath.spec.ts
@@ -17,7 +17,7 @@ describe('BitMath', () => {
 
   describe('#mostSignificantBit', () => {
     it('0', async () => {
-      await expect(bitMath.mostSignificantBit(0)).to.be.revertedWith('MSB')
+      await expect(bitMath.mostSignificantBit(0)).to.be.revertedWith('')
     })
     it('1', async () => {
       expect(await bitMath.mostSignificantBit(1)).to.eq(0)
@@ -48,7 +48,7 @@ describe('BitMath', () => {
 
   describe('#leastSignificantBit', () => {
     it('0', async () => {
-      await expect(bitMath.leastSignificantBit(0)).to.be.revertedWith('LSB')
+      await expect(bitMath.leastSignificantBit(0)).to.be.revertedWith('')
     })
     it('1', async () => {
       expect(await bitMath.leastSignificantBit(1)).to.eq(0)

--- a/test/SecondsOutside.spec.ts
+++ b/test/SecondsOutside.spec.ts
@@ -21,7 +21,7 @@ describe('SecondsOutside', () => {
 
   describe('#initialize', () => {
     it('reverts if tick is not multiple of tickSpacing', async () => {
-      await expect(secondsOutside.initialize(1, 8, 4, TEST_PAIR_START_TIME)).to.be.revertedWith('TS')
+      await expect(secondsOutside.initialize(1, 8, 4, TEST_PAIR_START_TIME)).to.be.revertedWith('')
     })
     it('tick 0 at current tick', async () => {
       const tick = 0

--- a/test/SqrtPriceMath.spec.ts
+++ b/test/SqrtPriceMath.spec.ts
@@ -30,7 +30,7 @@ describe('SqrtPriceMath', () => {
       const price = BigNumber.from(2).pow(160).sub(1)
       const liquidity = 1024
       const amountIn = 1024
-      await expect(sqrtPriceMath.getNextSqrtPriceFromInput(price, liquidity, amountIn, false)).to.be.revertedWith('DO')
+      await expect(sqrtPriceMath.getNextSqrtPriceFromInput(price, liquidity, amountIn, false)).to.be.revertedWith('')
     })
 
     it('any input amount cannot underflow the price', async () => {
@@ -138,9 +138,7 @@ describe('SqrtPriceMath', () => {
       const price = '20282409603651670423947251286016'
       const liquidity = 1024
       const amountOut = 5
-      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, false)).to.be.revertedWith(
-        'SO'
-      )
+      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, false)).to.be.revertedWith('')
     })
 
     it('succeeds if output amount is exactly the virtual reserves of token1', async () => {
@@ -155,7 +153,7 @@ describe('SqrtPriceMath', () => {
       const price = '20282409603651670423947251286016'
       const liquidity = 1024
       const amountOut = 262145
-      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, true)).to.be.revertedWith('SO')
+      await expect(sqrtPriceMath.getNextSqrtPriceFromOutput(price, liquidity, amountOut, true)).to.be.revertedWith('')
     })
 
     it('puzzling echidna test', async () => {
@@ -201,13 +199,13 @@ describe('SqrtPriceMath', () => {
     it('reverts if amountOut is impossible in zero for one direction', async () => {
       await expect(
         sqrtPriceMath.getNextSqrtPriceFromOutput(encodePriceSqrt(1, 1), 1, constants.MaxUint256, true)
-      ).to.be.revertedWith('FMD')
+      ).to.be.revertedWith('')
     })
 
     it('reverts if amountOut is impossible in one for zero direction', async () => {
       await expect(
         sqrtPriceMath.getNextSqrtPriceFromOutput(encodePriceSqrt(1, 1), 1, constants.MaxUint256, false)
-      ).to.be.revertedWith('SO')
+      ).to.be.revertedWith('')
     })
 
     it('zeroForOne = true gas', async () => {

--- a/test/UniswapV3Factory.spec.ts
+++ b/test/UniswapV3Factory.spec.ts
@@ -69,8 +69,8 @@ describe('UniswapV3Factory', () => {
       .to.emit(factory, 'PairCreated')
       .withArgs(TEST_ADDRESSES[0], TEST_ADDRESSES[1], feeAmount, tickSpacing, create2Address)
 
-    await expect(factory.createPair(tokens[0], tokens[1], feeAmount)).to.be.revertedWith('PAE')
-    await expect(factory.createPair(tokens[1], tokens[0], feeAmount)).to.be.revertedWith('PAE')
+    await expect(factory.createPair(tokens[0], tokens[1], feeAmount)).to.be.revertedWith('')
+    await expect(factory.createPair(tokens[1], tokens[0], feeAmount)).to.be.revertedWith('')
     expect(await factory.getPair(tokens[0], tokens[1], feeAmount), 'getPair in order').to.eq(create2Address)
     expect(await factory.getPair(tokens[1], tokens[0], feeAmount), 'getPair in reverse').to.eq(create2Address)
 
@@ -100,23 +100,19 @@ describe('UniswapV3Factory', () => {
     })
 
     it('fails if token a == token b', async () => {
-      await expect(factory.createPair(TEST_ADDRESSES[0], TEST_ADDRESSES[0], FeeAmount.LOW)).to.be.revertedWith('A=B')
+      await expect(factory.createPair(TEST_ADDRESSES[0], TEST_ADDRESSES[0], FeeAmount.LOW)).to.be.revertedWith('')
     })
 
     it('fails if token a is 0 or token b is 0', async () => {
-      await expect(factory.createPair(TEST_ADDRESSES[0], constants.AddressZero, FeeAmount.LOW)).to.be.revertedWith(
-        'A=0'
-      )
-      await expect(factory.createPair(constants.AddressZero, TEST_ADDRESSES[0], FeeAmount.LOW)).to.be.revertedWith(
-        'A=0'
-      )
+      await expect(factory.createPair(TEST_ADDRESSES[0], constants.AddressZero, FeeAmount.LOW)).to.be.revertedWith('')
+      await expect(factory.createPair(constants.AddressZero, TEST_ADDRESSES[0], FeeAmount.LOW)).to.be.revertedWith('')
       await expect(factory.createPair(constants.AddressZero, constants.AddressZero, FeeAmount.LOW)).to.be.revertedWith(
-        'A=B'
+        ''
       )
     })
 
     it('fails if fee amount is not enabled', async () => {
-      await expect(factory.createPair(TEST_ADDRESSES[0], TEST_ADDRESSES[1], 250)).to.be.revertedWith('FNA')
+      await expect(factory.createPair(TEST_ADDRESSES[0], TEST_ADDRESSES[1], 250)).to.be.revertedWith('')
     })
 
     it('gas', async () => {
@@ -126,7 +122,7 @@ describe('UniswapV3Factory', () => {
 
   describe('#setOwner', () => {
     it('fails if caller is not owner', async () => {
-      await expect(factory.connect(other).setOwner(wallet.address)).to.be.revertedWith('OO')
+      await expect(factory.connect(other).setOwner(wallet.address)).to.be.revertedWith('')
     })
 
     it('updates owner', async () => {
@@ -142,26 +138,26 @@ describe('UniswapV3Factory', () => {
 
     it('cannot be called by original owner', async () => {
       await factory.setOwner(other.address)
-      await expect(factory.setOwner(wallet.address)).to.be.revertedWith('OO')
+      await expect(factory.setOwner(wallet.address)).to.be.revertedWith('')
     })
   })
 
   describe('#enableFeeAmount', () => {
     it('fails if caller is not owner', async () => {
-      await expect(factory.connect(other).enableFeeAmount(100, 2)).to.be.revertedWith('OO')
+      await expect(factory.connect(other).enableFeeAmount(100, 2)).to.be.revertedWith('')
     })
     it('fails if fee is too great', async () => {
-      await expect(factory.enableFeeAmount(1000000, 10)).to.be.revertedWith('FEE')
+      await expect(factory.enableFeeAmount(1000000, 10)).to.be.revertedWith('')
     })
     it('fails if tick spacing is too small', async () => {
-      await expect(factory.enableFeeAmount(500, 0)).to.be.revertedWith('TS')
+      await expect(factory.enableFeeAmount(500, 0)).to.be.revertedWith('')
     })
     it('fails if tick spacing is too large', async () => {
-      await expect(factory.enableFeeAmount(500, 16834)).to.be.revertedWith('TS')
+      await expect(factory.enableFeeAmount(500, 16834)).to.be.revertedWith('')
     })
     it('fails if already initialized', async () => {
       await factory.enableFeeAmount(100, 5)
-      await expect(factory.enableFeeAmount(100, 10)).to.be.revertedWith('FAI')
+      await expect(factory.enableFeeAmount(100, 10)).to.be.revertedWith('')
     })
     it('sets the fee amount in the mapping', async () => {
       await factory.enableFeeAmount(100, 5)

--- a/test/UniswapV3Pair.spec.ts
+++ b/test/UniswapV3Pair.spec.ts
@@ -932,12 +932,12 @@ describe('UniswapV3Pair', () => {
     })
 
     it('cannot be changed out of bounds', async () => {
-      await expect(pair.setFeeProtocol(3)).to.be.revertedWith('FP')
-      await expect(pair.setFeeProtocol(11)).to.be.revertedWith('FP')
+      await expect(pair.setFeeProtocol(3)).to.be.revertedWith('')
+      await expect(pair.setFeeProtocol(11)).to.be.revertedWith('')
     })
 
     it('cannot be changed by addresses that are not owner', async () => {
-      await expect(pair.connect(other).setFeeProtocol(6)).to.be.revertedWith('OO')
+      await expect(pair.connect(other).setFeeProtocol(6)).to.be.revertedWith('')
     })
 
     async function swapAndGetFeesOwed({
@@ -1171,8 +1171,8 @@ describe('UniswapV3Pair', () => {
           await pair.initialize(encodePriceSqrt(1, 1))
         })
         it('mint can only be called for multiples of 12', async () => {
-          await expect(mint(wallet.address, -6, 0, 1)).to.be.revertedWith('TS')
-          await expect(mint(wallet.address, 0, 6, 1)).to.be.revertedWith('TS')
+          await expect(mint(wallet.address, -6, 0, 1)).to.be.revertedWith('')
+          await expect(mint(wallet.address, 0, 6, 1)).to.be.revertedWith('')
         })
         it('mint can be called with multiples of 12', async () => {
           await mint(wallet.address, 12, 24, 1)

--- a/test/__snapshots__/UniswapV3Factory.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Factory.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Factory #createPair gas 1`] = `4633329`;
+exports[`UniswapV3Factory #createPair gas 1`] = `4501033`;
 
-exports[`UniswapV3Factory factory bytecode size 1`] = `25503`;
+exports[`UniswapV3Factory factory bytecode size 1`] = `24433`;
 
-exports[`UniswapV3Factory pair bytecode size 1`] = `22505`;
+exports[`UniswapV3Factory pair bytecode size 1`] = `21846`;

--- a/test/__snapshots__/UniswapV3Pair.gas.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Pair.gas.spec.ts.snap
@@ -4,25 +4,25 @@ exports[`UniswapV3Pair gas tests fee is off #burn above current price burn entir
 
 exports[`UniswapV3Pair gas tests fee is off #burn above current price burn when only position using ticks 1`] = `56685`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn above current price entire position burn but other positions are using the ticks 1`] = `76676`;
+exports[`UniswapV3Pair gas tests fee is off #burn above current price entire position burn but other positions are using the ticks 1`] = `76675`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn above current price partial position burn 1`] = `90049`;
+exports[`UniswapV3Pair gas tests fee is off #burn above current price partial position burn 1`] = `90048`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn around current price burn entire position after some time passes 1`] = `83352`;
+exports[`UniswapV3Pair gas tests fee is off #burn around current price burn entire position after some time passes 1`] = `83351`;
 
 exports[`UniswapV3Pair gas tests fee is off #burn around current price burn when only position using ticks 1`] = `80028`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn around current price entire position burn but other positions are using the ticks 1`] = `104559`;
+exports[`UniswapV3Pair gas tests fee is off #burn around current price entire position burn but other positions are using the ticks 1`] = `104558`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn around current price partial position burn 1`] = `117932`;
+exports[`UniswapV3Pair gas tests fee is off #burn around current price partial position burn 1`] = `117931`;
 
 exports[`UniswapV3Pair gas tests fee is off #burn below current price burn entire position after some time passes 1`] = `69507`;
 
 exports[`UniswapV3Pair gas tests fee is off #burn below current price burn when only position using ticks 1`] = `69507`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn below current price entire position burn but other positions are using the ticks 1`] = `77314`;
+exports[`UniswapV3Pair gas tests fee is off #burn below current price entire position burn but other positions are using the ticks 1`] = `77313`;
 
-exports[`UniswapV3Pair gas tests fee is off #burn below current price partial position burn 1`] = `90687`;
+exports[`UniswapV3Pair gas tests fee is off #burn below current price partial position burn 1`] = `90686`;
 
 exports[`UniswapV3Pair gas tests fee is off #collect close to worst case 1`] = `41817`;
 
@@ -78,25 +78,25 @@ exports[`UniswapV3Pair gas tests fee is on #burn above current price burn entire
 
 exports[`UniswapV3Pair gas tests fee is on #burn above current price burn when only position using ticks 1`] = `56685`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn above current price entire position burn but other positions are using the ticks 1`] = `76676`;
+exports[`UniswapV3Pair gas tests fee is on #burn above current price entire position burn but other positions are using the ticks 1`] = `76675`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn above current price partial position burn 1`] = `90049`;
+exports[`UniswapV3Pair gas tests fee is on #burn above current price partial position burn 1`] = `90048`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn around current price burn entire position after some time passes 1`] = `83352`;
+exports[`UniswapV3Pair gas tests fee is on #burn around current price burn entire position after some time passes 1`] = `83351`;
 
 exports[`UniswapV3Pair gas tests fee is on #burn around current price burn when only position using ticks 1`] = `80028`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn around current price entire position burn but other positions are using the ticks 1`] = `104559`;
+exports[`UniswapV3Pair gas tests fee is on #burn around current price entire position burn but other positions are using the ticks 1`] = `104558`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn around current price partial position burn 1`] = `117932`;
+exports[`UniswapV3Pair gas tests fee is on #burn around current price partial position burn 1`] = `117931`;
 
 exports[`UniswapV3Pair gas tests fee is on #burn below current price burn entire position after some time passes 1`] = `69507`;
 
 exports[`UniswapV3Pair gas tests fee is on #burn below current price burn when only position using ticks 1`] = `69507`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn below current price entire position burn but other positions are using the ticks 1`] = `77314`;
+exports[`UniswapV3Pair gas tests fee is on #burn below current price entire position burn but other positions are using the ticks 1`] = `77313`;
 
-exports[`UniswapV3Pair gas tests fee is on #burn below current price partial position burn 1`] = `90687`;
+exports[`UniswapV3Pair gas tests fee is on #burn below current price partial position burn 1`] = `90686`;
 
 exports[`UniswapV3Pair gas tests fee is on #collect close to worst case 1`] = `41817`;
 


### PR DESCRIPTION
remove revert reasons that
- should not be encountered by the user, e.g. validating that two addresses are not equal, or equal to 0
- come from checking against immutable state, e.g. tick spacing, and thus these transactions should never be constructed in the interface
- the above, but also things that very rarely change like allowed pair fees, or factory owner, for the same reason
- thrown in many places, and the reason string alone is not enough to identify the problem
- are thrown in an internal library but that call path is prevented elsewhere, e.g. MSB/LSB should never be encountered