### PR TITLE
Arbitrary length exact output multi-hops

### DIFF
--- a/contracts/test/TestUniswapV3Router.sol
+++ b/contracts/test/TestUniswapV3Router.sol
@@ -3,8 +3,7 @@ pragma solidity =0.7.6;
 
 import '../libraries/SafeCast.sol';
 import '../libraries/TickMath.sol';
-import "hardhat/console.sol";
-
+import 'hardhat/console.sol';
 
 import '../interfaces/IERC20Minimal.sol';
 import '../interfaces/callback/IUniswapV3SwapCallback.sol';
@@ -13,7 +12,6 @@ import '../interfaces/IUniswapV3Pair.sol';
 contract TestUniswapV3Router is IUniswapV3SwapCallback {
     using SafeCast for uint256;
 
-
     // swaps 0 for exact 1 arbitrary length multihop
     function swap0ForExact1Multi(
         address recipient,
@@ -21,23 +19,23 @@ contract TestUniswapV3Router is IUniswapV3SwapCallback {
         uint256 amount1Out
     ) external {
         bool originZeroForOne = true;
-        uint numRemainingSwaps = pairs.length - 1;
-        IUniswapV3Pair(pairs[numRemainingSwaps]).swap( 
+        uint256 numRemainingSwaps = pairs.length - 1;
+        IUniswapV3Pair(pairs[numRemainingSwaps]).swap(
             recipient,
             true,
             -amount1Out.toInt256(),
             TickMath.MIN_SQRT_RATIO + 1,
             abi.encode(numRemainingSwaps, originZeroForOne, pairs, msg.sender)
         );
-    }    
-    
+    }
+
     // swaps 1 for exact 0 arbitrary length multihop
     function swap1ForExact0Multi(
         address recipient,
         address[] memory pairs,
         uint256 amount0Out
     ) external {
-        uint numRemainingSwaps = pairs.length - 1;
+        uint256 numRemainingSwaps = pairs.length - 1;
         bool originZeroForOne = false;
         IUniswapV3Pair(pairs[numRemainingSwaps]).swap(
             recipient,
@@ -46,7 +44,7 @@ contract TestUniswapV3Router is IUniswapV3SwapCallback {
             TickMath.MAX_SQRT_RATIO - 1,
             abi.encode(numRemainingSwaps, originZeroForOne, pairs, msg.sender)
         );
-    }   
+    }
 
     // swaps 0 for exact 0 arbitrary length multihop
     function swap0ForExact0Multi(
@@ -55,15 +53,15 @@ contract TestUniswapV3Router is IUniswapV3SwapCallback {
         uint256 amount0Out
     ) external {
         bool originZeroForOne = true;
-        uint numRemainingSwaps = pairs.length - 1;
-        IUniswapV3Pair(pairs[numRemainingSwaps]).swap( 
+        uint256 numRemainingSwaps = pairs.length - 1;
+        IUniswapV3Pair(pairs[numRemainingSwaps]).swap(
             recipient,
             false,
             -amount0Out.toInt256(),
             TickMath.MAX_SQRT_RATIO - 1,
             abi.encode(numRemainingSwaps, originZeroForOne, pairs, msg.sender)
         );
-    }    
+    }
 
     // swaps 1 for exact 1 arbitrary length multihop
     function swap1ForExact1Multi(
@@ -72,16 +70,16 @@ contract TestUniswapV3Router is IUniswapV3SwapCallback {
         uint256 amount1Out
     ) external {
         bool originZeroForOne = false;
-        uint numRemainingSwaps = pairs.length - 1;
-        IUniswapV3Pair(pairs[numRemainingSwaps]).swap( 
+        uint256 numRemainingSwaps = pairs.length - 1;
+        IUniswapV3Pair(pairs[numRemainingSwaps]).swap(
             recipient,
             true,
             -amount1Out.toInt256(),
             TickMath.MIN_SQRT_RATIO + 1,
             abi.encode(numRemainingSwaps, originZeroForOne, pairs, msg.sender)
         );
-    }      
- 
+    }
+
     event SwapCallback(int256 amount0Delta, int256 amount1Delta);
 
     function uniswapV3SwapCallback(
@@ -91,39 +89,36 @@ contract TestUniswapV3Router is IUniswapV3SwapCallback {
     ) public override {
         emit SwapCallback(amount0Delta, amount1Delta);
 
-        (uint numRemainingSwaps, bool originZeroForOne, address[] memory pairs, address payer) = 
-        abi.decode(data, (uint, bool, address[], address));
+        (uint256 numRemainingSwaps, bool originZeroForOne, address[] memory pairs, address payer) =
+            abi.decode(data, (uint256, bool, address[], address));
 
         if (numRemainingSwaps > 0) {
             numRemainingSwaps--;
             // get the address, amount, and direction of the token that we need to pay
             address tokenToBePaid =
                 amount0Delta > 0 ? IUniswapV3Pair(msg.sender).token0() : IUniswapV3Pair(msg.sender).token1();
-            int256 amountToBePaid = 
-                amount0Delta > 0 ? amount0Delta : amount1Delta;
-            bool zeroForOne = 
-                tokenToBePaid == IUniswapV3Pair(pairs[numRemainingSwaps]).token1();
+            int256 amountToBePaid = amount0Delta > 0 ? amount0Delta : amount1Delta;
+            bool zeroForOne = tokenToBePaid == IUniswapV3Pair(pairs[numRemainingSwaps]).token1();
 
-                IUniswapV3Pair(pairs[numRemainingSwaps]).swap(
-                    msg.sender,
-                    zeroForOne,
-                    -amountToBePaid,
-                    zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1,
-                    abi.encode(numRemainingSwaps, originZeroForOne, pairs, payer)
+            IUniswapV3Pair(pairs[numRemainingSwaps]).swap(
+                msg.sender,
+                zeroForOne,
+                -amountToBePaid,
+                zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1,
+                abi.encode(numRemainingSwaps, originZeroForOne, pairs, payer)
             );
-     } else {
-            originZeroForOne ?
-                IERC20Minimal(IUniswapV3Pair(msg.sender).token0()).transferFrom(
+        } else {
+            originZeroForOne
+                ? IERC20Minimal(IUniswapV3Pair(msg.sender).token0()).transferFrom(
                     payer,
                     msg.sender,
                     uint256(amount0Delta)
-                ) :
-                IERC20Minimal(IUniswapV3Pair(msg.sender).token1()).transferFrom(
+                )
+                : IERC20Minimal(IUniswapV3Pair(msg.sender).token1()).transferFrom(
                     payer,
                     msg.sender,
                     uint256(amount1Delta)
                 );
-            
         }
     }
 }

--- a/test/UniswapV3Router.spec.ts
+++ b/test/UniswapV3Router.spec.ts
@@ -136,9 +136,7 @@ describe('Test Router Multi-hop', () => {
       await pair2ReversedFunctions.mint(wallet.address, minTick, maxTick, expandTo18Decimals(1))
     })
 
-
     it('Swap 0 for exact 1', async () => {
-      
       outputToken = token3
 
       const { swap0ForExact1Multi } = createMultiPairFunctions({
@@ -149,9 +147,9 @@ describe('Test Router Multi-hop', () => {
         pairOutput: pair2,
       })
 
-      const method =  swap0ForExact1Multi
+      const method = swap0ForExact1Multi
 
-        await expect(method(100, wallet.address))
+      await expect(method(100, wallet.address))
         .to.emit(outputToken, 'Transfer')
         .withArgs(pair2.address, wallet.address, 100)
         .to.emit(token2, 'Transfer')
@@ -162,7 +160,6 @@ describe('Test Router Multi-hop', () => {
         .withArgs(wallet.address, pair0.address, 106)
     })
     it('Swap 1 for exact 0', async () => {
-      
       outputToken = token3
 
       const { swap1ForExact0Multi } = createMultiPairFunctions({
@@ -175,7 +172,7 @@ describe('Test Router Multi-hop', () => {
 
       const method = swap1ForExact0Multi
 
-        await expect(method(100, wallet.address))
+      await expect(method(100, wallet.address))
         .to.emit(outputToken, 'Transfer')
         .withArgs(pair2Reversed.address, wallet.address, 100)
         .to.emit(token2, 'Transfer')
@@ -186,7 +183,6 @@ describe('Test Router Multi-hop', () => {
         .withArgs(wallet.address, pair0Reversed.address, 106)
     })
     it('Swap 0 for exact 0', async () => {
-      
       outputToken = token3
 
       const { swap0ForExact0Multi } = createMultiPairFunctions({
@@ -199,7 +195,7 @@ describe('Test Router Multi-hop', () => {
 
       const method = swap0ForExact0Multi
 
-        await expect(method(100, wallet.address))
+      await expect(method(100, wallet.address))
         .to.emit(outputToken, 'Transfer')
         .withArgs(pair2Reversed.address, wallet.address, 100)
         .to.emit(token2, 'Transfer')
@@ -210,7 +206,6 @@ describe('Test Router Multi-hop', () => {
         .withArgs(wallet.address, pair0.address, 106)
     })
     it('Swap 1 for exact 1', async () => {
-      
       outputToken = token3
 
       const { swap1ForExact1Multi } = createMultiPairFunctions({
@@ -223,7 +218,7 @@ describe('Test Router Multi-hop', () => {
 
       const method = swap1ForExact1Multi
 
-        await expect(method(100, wallet.address))
+      await expect(method(100, wallet.address))
         .to.emit(outputToken, 'Transfer')
         .withArgs(pair2.address, wallet.address, 100)
         .to.emit(token2, 'Transfer')

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -33,7 +33,6 @@ async function tokensFixture(): Promise<TokensFixture> {
   const tokenC = (await tokenFactory.deploy(BigNumber.from(2).pow(255))) as TestERC20
   const tokenD = (await tokenFactory.deploy(BigNumber.from(2).pow(255))) as TestERC20
 
-
   const [token0, token1, token2, token3] = [tokenA, tokenB, tokenC, tokenD].sort((tokenA, tokenB) =>
     tokenA.address.toLowerCase() < tokenB.address.toLowerCase() ? -1 : 1
   )

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -258,11 +258,10 @@ export function createMultiPairFunctions({
     return method(toAddress, [pairInput.address, intermediaryPair.address, pairOutput.address], amountOut)
   }
 
-
   return {
     swap0ForExact1Multi,
     swap1ForExact0Multi,
     swap0ForExact0Multi,
-    swap1ForExact1Multi
+    swap1ForExact1Multi,
   }
 }


### PR DESCRIPTION
Alters previous router exploration to accept arbitrary length multi hops, including swapping token 1 for 1 and 0 for 0.

Thought this may be helpful for @gakonst - if not feel free to close!