### PR TITLE
feat: add router v3 interface

### DIFF
--- a/contracts/periphery/interfaces/IUniswapV3Router01.sol
+++ b/contracts/periphery/interfaces/IUniswapV3Router01.sol
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.7.6;
 
-import { IUniswapV3SwapCallback } from '../../interfaces/callback/IUniswapV3SwapCallback.sol';
-import { IUniswapV3MintCallback } from '../../interfaces/callback/IUniswapV3MintCallback.sol';
+import {IUniswapV3SwapCallback} from '../../interfaces/callback/IUniswapV3SwapCallback.sol';
+import {IUniswapV3MintCallback} from '../../interfaces/callback/IUniswapV3MintCallback.sol';
 
 interface RouterBase {
     /// Gets the spot price for a given amount, by checking the pair's liquidit and current sqrt price
-    function quote(uint amountA, uint128 liquidity, uint160 sqrtPriceX96) external pure returns (uint amountB);
+    function quote(
+        uint256 amountA,
+        uint128 liquidity,
+        uint160 sqrtPriceX96
+    ) external pure returns (uint256 amountB);
 
     /// Returns the UniswapV3 factory
     function factory() external pure returns (address);
@@ -15,14 +19,14 @@ interface RouterBase {
     function WETH() external pure returns (address);
 
     /// The amount to be received given `amountIn` to the provided `pair`
-    function getAmountOut(uint amountIn, address pair) external pure returns (uint amountOut);
+    function getAmountOut(uint256 amountIn, address pair) external pure returns (uint256 amountOut);
 
     /// The amount to be sent given `amountOut` to the provided `pair`
-    function getAmountIn(uint amountOut, address pair) external pure returns (uint amountIn);
+    function getAmountIn(uint256 amountOut, address pair) external pure returns (uint256 amountIn);
 
-    function getAmountsOut(uint amountIn, bytes32[] calldata path) external view returns (uint[] memory amounts);
+    function getAmountsOut(uint256 amountIn, bytes32[] calldata path) external view returns (uint256[] memory amounts);
 
-    function getAmountsIn(uint amountOut, bytes32[] calldata path) external view returns (uint[] memory amounts);
+    function getAmountsIn(uint256 amountOut, bytes32[] calldata path) external view returns (uint256[] memory amounts);
 }
 
 interface RouterTokenSwaps is IUniswapV3SwapCallback {
@@ -32,7 +36,7 @@ interface RouterTokenSwaps is IUniswapV3SwapCallback {
         bytes32[] calldata path, // TODO: Change this to a bytes buffer and just slice it?
         address recipient,
         uint256 deadline
-    ) external returns (uint[] memory amounts);
+    ) external returns (uint256[] memory amounts);
 
     function swapTokensForExactTokens(
         uint256 amount1Out,
@@ -40,7 +44,7 @@ interface RouterTokenSwaps is IUniswapV3SwapCallback {
         bytes32[] calldata path,
         address recipient,
         uint256 deadline
-    ) external returns (uint[] memory amounts);
+    ) external returns (uint256[] memory amounts);
 
     // TODO: Add ETH, Permits, Fee on Transfer
 }
@@ -56,13 +60,19 @@ interface RouterLP is IUniswapV3MintCallback {
         uint256 fee,
         int24 tickLower,
         int24 tickUpper,
-        uint amountADesired,
-        uint amountBDesired,
-        uint amountAMin,
-        uint amountBMin,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
         address recipient,
-        uint deadline
-    ) external returns (uint amountA, uint amountB, uint liquidity);
+        uint256 deadline
+    )
+        external
+        returns (
+            uint256 amountA,
+            uint256 amountB,
+            uint256 liquidity
+        );
 
     function removeLiquidity(
         // Params
@@ -71,14 +81,14 @@ interface RouterLP is IUniswapV3MintCallback {
         uint256 fee,
         int24 tickLower,
         int24 tickUpper,
-        uint liquidity,
+        uint256 liquidity,
         // Recipient
         address recipient,
         // Consistency checks
-        uint amountAMin,
-        uint amountBMin,
-        uint deadline
-    ) external returns (uint amountA, uint amountB);
+        uint256 amountAMin,
+        uint256 amountBMin,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB);
 
     // TODO: Add ETH, Permits, Fee on Transfer
 }


### PR DESCRIPTION
An initial attempt, this is pretty close to the V2 Router. 3 Main changes
* Given how the Uniswap state transition is hard to write as a pure function due to the ticks mapping (mappings cannot be passed as public function args, only in internal Libraries), the `getAmount` functions use a `pair` address which they'll call to get any tick-related state they need.
* `path` is no longer an `address[]` but a `bytes32[]`. That will allow us to have the address of the token being swapped in the lower 20 bytes, and have the fee category in the upper 12 bytes.
* Instead of using min/max amounts when swapping, we use `sqrtPriceLimitX96`.


Questions:
* Currently, if `amountADesired` is set to 0, then you do "single sided" liquidity adding, by swapping then minting. Should this be done in a separate function?
* Should we add `sqrtPriceLimitX96` instead of `amountAMin` and `amountBMin`in addLiquidity`?
* Is exposing the state transition function as a `view` function an option or are we frozen? That would greatly simplify the implementations of `getAmountOut`
* It is still a bit unclear how we'll do multihop `exactIn` because we need to run the state transition function in reverse (and that may require non trivial math changes, but I haven't checked yet).
* Kinda feels like the `address; address; uint256` combo is a few too-many function args (stack too deep etc.), should we just pack them in a struct and use abi encoder v2?