### PR TITLE
Add compability for solc 0.8

### DIFF
--- a/contracts/libraries/BitMath.sol
+++ b/contracts/libraries/BitMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 /// @title BitMath
 /// @dev This library provides functionality for computing bit properties of an unsigned integer
@@ -11,37 +11,39 @@ library BitMath {
     /// @param x the value for which to compute the most significant bit, must be greater than 0
     /// @return r the index of the most significant bit
     function mostSignificantBit(uint256 x) internal pure returns (uint8 r) {
-        require(x > 0);
+        unchecked {
+            require(x > 0);
 
-        if (x >= 0x100000000000000000000000000000000) {
-            x >>= 128;
-            r += 128;
+            if (x >= 0x100000000000000000000000000000000) {
+                x >>= 128;
+                r += 128;
+            }
+            if (x >= 0x10000000000000000) {
+                x >>= 64;
+                r += 64;
+            }
+            if (x >= 0x100000000) {
+                x >>= 32;
+                r += 32;
+            }
+            if (x >= 0x10000) {
+                x >>= 16;
+                r += 16;
+            }
+            if (x >= 0x100) {
+                x >>= 8;
+                r += 8;
+            }
+            if (x >= 0x10) {
+                x >>= 4;
+                r += 4;
+            }
+            if (x >= 0x4) {
+                x >>= 2;
+                r += 2;
+            }
+            if (x >= 0x2) r += 1;
         }
-        if (x >= 0x10000000000000000) {
-            x >>= 64;
-            r += 64;
-        }
-        if (x >= 0x100000000) {
-            x >>= 32;
-            r += 32;
-        }
-        if (x >= 0x10000) {
-            x >>= 16;
-            r += 16;
-        }
-        if (x >= 0x100) {
-            x >>= 8;
-            r += 8;
-        }
-        if (x >= 0x10) {
-            x >>= 4;
-            r += 4;
-        }
-        if (x >= 0x4) {
-            x >>= 2;
-            r += 2;
-        }
-        if (x >= 0x2) r += 1;
     }
 
     /// @notice Returns the index of the least significant bit of the number,
@@ -51,44 +53,46 @@ library BitMath {
     /// @param x the value for which to compute the least significant bit, must be greater than 0
     /// @return r the index of the least significant bit
     function leastSignificantBit(uint256 x) internal pure returns (uint8 r) {
-        require(x > 0);
+        unchecked {
+            require(x > 0);
 
-        r = 255;
-        if (x & type(uint128).max > 0) {
-            r -= 128;
-        } else {
-            x >>= 128;
+            r = 255;
+            if (x & type(uint128).max > 0) {
+                r -= 128;
+            } else {
+                x >>= 128;
+            }
+            if (x & type(uint64).max > 0) {
+                r -= 64;
+            } else {
+                x >>= 64;
+            }
+            if (x & type(uint32).max > 0) {
+                r -= 32;
+            } else {
+                x >>= 32;
+            }
+            if (x & type(uint16).max > 0) {
+                r -= 16;
+            } else {
+                x >>= 16;
+            }
+            if (x & type(uint8).max > 0) {
+                r -= 8;
+            } else {
+                x >>= 8;
+            }
+            if (x & 0xf > 0) {
+                r -= 4;
+            } else {
+                x >>= 4;
+            }
+            if (x & 0x3 > 0) {
+                r -= 2;
+            } else {
+                x >>= 2;
+            }
+            if (x & 0x1 > 0) r -= 1;
         }
-        if (x & type(uint64).max > 0) {
-            r -= 64;
-        } else {
-            x >>= 64;
-        }
-        if (x & type(uint32).max > 0) {
-            r -= 32;
-        } else {
-            x >>= 32;
-        }
-        if (x & type(uint16).max > 0) {
-            r -= 16;
-        } else {
-            x >>= 16;
-        }
-        if (x & type(uint8).max > 0) {
-            r -= 8;
-        } else {
-            x >>= 8;
-        }
-        if (x & 0xf > 0) {
-            r -= 4;
-        } else {
-            x >>= 4;
-        }
-        if (x & 0x3 > 0) {
-            r -= 2;
-        } else {
-            x >>= 2;
-        }
-        if (x & 0x1 > 0) r -= 1;
     }
 }

--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.0;
+pragma solidity >=0.8.0;
 
 /// @title Contains 512-bit math functions
 /// @notice Facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision
@@ -127,10 +127,12 @@ library FullMath {
         uint256 b,
         uint256 denominator
     ) internal pure returns (uint256 result) {
-        result = mulDiv(a, b, denominator);
-        if (mulmod(a, b, denominator) > 0) {
-            require(result < type(uint256).max);
-            result++;
+        unchecked {
+            result = mulDiv(a, b, denominator);
+            if (mulmod(a, b, denominator) > 0) {
+                require(result < type(uint256).max);
+                result++;
+            }
         }
     }
 }

--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -61,7 +61,8 @@ library FullMath {
         // Factor powers of two out of denominator
         // Compute largest power of two divisor of denominator.
         // Always >= 1.
-        uint256 twos = -denominator & denominator;
+        // Cannot overflow because denominator != 0
+        uint256 twos = (type(uint256).max - denominator + 1) & denominator;
         // Divide denominator by power of two
         assembly {
             denominator := div(denominator, twos)
@@ -76,24 +77,30 @@ library FullMath {
         // If twos is zero, then it becomes one
         assembly {
             twos := add(div(sub(0, twos), twos), 1)
+            prod0 := or(prod0, mul(prod1, twos))
         }
-        prod0 |= prod1 * twos;
 
         // Invert denominator mod 2**256
         // Now that denominator is an odd number, it has an inverse
         // modulo 2**256 such that denominator * inv = 1 mod 2**256.
         // Compute the inverse by starting with a seed that is correct
         // correct for four bits. That is, denominator * inv = 1 mod 2**4
-        uint256 inv = (3 * denominator) ^ 2;
+        uint256 inv;
+
+        assembly {
+            inv := xor(mul(3, denominator), 2)
+        }
         // Now use Newton-Raphson iteration to improve the precision.
         // Thanks to Hensel's lifting lemma, this also works in modular
         // arithmetic, doubling the correct bits in each step.
-        inv *= 2 - denominator * inv; // inverse mod 2**8
-        inv *= 2 - denominator * inv; // inverse mod 2**16
-        inv *= 2 - denominator * inv; // inverse mod 2**32
-        inv *= 2 - denominator * inv; // inverse mod 2**64
-        inv *= 2 - denominator * inv; // inverse mod 2**128
-        inv *= 2 - denominator * inv; // inverse mod 2**256
+        assembly {
+            inv := mul(inv, sub(2, mul(denominator, inv))) // inverse mod 2**8
+            inv := mul(inv, sub(2, mul(denominator, inv))) // inverse mod 2**16
+            inv := mul(inv, sub(2, mul(denominator, inv))) // inverse mod 2**32
+            inv := mul(inv, sub(2, mul(denominator, inv))) // inverse mod 2**64
+            inv := mul(inv, sub(2, mul(denominator, inv))) // inverse mod 2**128
+            inv := mul(inv, sub(2, mul(denominator, inv))) // inverse mod 2**256
+        }
 
         // Because the division is now exact we can divide by multiplying
         // with the modular inverse of denominator. This will give us the
@@ -101,7 +108,9 @@ library FullMath {
         // that the outcome is less than 2**256, this is the final result.
         // We don't need to compute the high bits of the result and prod1
         // is no longer required.
-        result = prod0 * inv;
+        assembly {
+            result := mul(prod0, inv)
+        }
         return result;
     }
 

--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -62,7 +62,10 @@ library FullMath {
         // Compute largest power of two divisor of denominator.
         // Always >= 1.
         // Cannot overflow because denominator != 0
-        uint256 twos = (type(uint256).max - denominator + 1) & denominator;
+        uint256 twos;
+        assembly {
+            twos := and(add(not(denominator), 1), denominator)
+        }
         // Divide denominator by power of two
         assembly {
             denominator := div(denominator, twos)

--- a/contracts/libraries/LiquidityMath.sol
+++ b/contracts/libraries/LiquidityMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 /// @title Math library for liquidity
 library LiquidityMath {
@@ -8,10 +8,12 @@ library LiquidityMath {
     /// @param y The delta by which liquidity should be changed
     /// @return z The liquidity delta
     function addDelta(uint128 x, int128 y) internal pure returns (uint128 z) {
-        if (y < 0) {
-            require((z = x - uint128(-y)) < x, 'LS');
-        } else {
-            require((z = x + uint128(y)) >= x, 'LA');
+        unchecked {
+            if (y < 0) {
+                require((z = x - uint128(-y)) < x, 'LS');
+            } else {
+                require((z = x + uint128(y)) >= x, 'LA');
+            }
         }
     }
 }

--- a/contracts/libraries/LowGasSafeMath.sol
+++ b/contracts/libraries/LowGasSafeMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.7.0;
+pragma solidity >=0.8.0;
 
 /// @title Optimized overflow and underflow safe math operations
 /// @notice Contains methods for doing math operations that revert on overflow or underflow for minimal gas cost
@@ -9,7 +9,9 @@ library LowGasSafeMath {
     /// @param y The addend
     /// @return z The sum of x and y
     function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require((z = x + y) >= x);
+        unchecked {
+            require((z = x + y) >= x);
+        }
     }
 
     /// @notice Returns x - y, reverts if underflows
@@ -17,7 +19,9 @@ library LowGasSafeMath {
     /// @param y The subtrahend
     /// @return z The difference of x and y
     function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require((z = x - y) <= x);
+        unchecked {
+            require((z = x - y) <= x);
+        }
     }
 
     /// @notice Returns x * y, reverts if overflows
@@ -25,7 +29,9 @@ library LowGasSafeMath {
     /// @param y The multiplier
     /// @return z The product of x and y
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require(x == 0 || (z = x * y) / x == y);
+        unchecked {
+            require(x == 0 || (z = x * y) / x == y);
+        }
     }
 
     /// @notice Returns x + y, reverts if overflows or underflows
@@ -33,7 +39,9 @@ library LowGasSafeMath {
     /// @param y The addend
     /// @return z The sum of x and y
     function add(int256 x, int256 y) internal pure returns (int256 z) {
-        require((z = x + y) >= x == (y >= 0));
+        unchecked {
+            require((z = x + y) >= x == (y >= 0));
+        }
     }
 
     /// @notice Returns x - y, reverts if overflows or underflows
@@ -41,6 +49,8 @@ library LowGasSafeMath {
     /// @param y The subtrahend
     /// @return z The difference of x and y
     function sub(int256 x, int256 y) internal pure returns (int256 z) {
-        require((z = x - y) <= x == (y >= 0));
+        unchecked {
+            require((z = x - y) <= x == (y >= 0));
+        }
     }
 }

--- a/contracts/libraries/Oracle.sol
+++ b/contracts/libraries/Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 /// @title Oracle
 /// @notice Provides price and liquidity data useful for a wide variety of system designs
@@ -33,15 +33,17 @@ library Oracle {
         int24 tick,
         uint128 liquidity
     ) private pure returns (Observation memory) {
-        uint32 delta = blockTimestamp - last.blockTimestamp;
-        return
-            Observation({
-                blockTimestamp: blockTimestamp,
-                tickCumulative: last.tickCumulative + int56(tick) * delta,
-                secondsPerLiquidityCumulativeX128: last.secondsPerLiquidityCumulativeX128 +
-                    ((uint160(delta) << 128) / (liquidity > 0 ? liquidity : 1)),
-                initialized: true
-            });
+        unchecked {
+            uint32 delta = blockTimestamp - last.blockTimestamp;
+            return
+                Observation({
+                    blockTimestamp: blockTimestamp,
+                    tickCumulative: last.tickCumulative + int56(tick) * int56(uint56(delta)),
+                    secondsPerLiquidityCumulativeX128: last.secondsPerLiquidityCumulativeX128 +
+                        ((uint160(delta) << 128) / (liquidity > 0 ? liquidity : 1)),
+                    initialized: true
+                });
+        }
     }
 
     /// @notice Initialize the oracle array by writing the first slot. Called once for the lifecycle of the observations array
@@ -53,13 +55,15 @@ library Oracle {
         internal
         returns (uint16 cardinality, uint16 cardinalityNext)
     {
-        self[0] = Observation({
-            blockTimestamp: time,
-            tickCumulative: 0,
-            secondsPerLiquidityCumulativeX128: 0,
-            initialized: true
-        });
-        return (1, 1);
+        unchecked {
+            self[0] = Observation({
+                blockTimestamp: time,
+                tickCumulative: 0,
+                secondsPerLiquidityCumulativeX128: 0,
+                initialized: true
+            });
+            return (1, 1);
+        }
     }
 
     /// @notice Writes an oracle observation to the array
@@ -84,20 +88,22 @@ library Oracle {
         uint16 cardinality,
         uint16 cardinalityNext
     ) internal returns (uint16 indexUpdated, uint16 cardinalityUpdated) {
-        Observation memory last = self[index];
+        unchecked {
+            Observation memory last = self[index];
 
-        // early return if we've already written an observation this block
-        if (last.blockTimestamp == blockTimestamp) return (index, cardinality);
+            // early return if we've already written an observation this block
+            if (last.blockTimestamp == blockTimestamp) return (index, cardinality);
 
-        // if the conditions are right, we can bump the cardinality
-        if (cardinalityNext > cardinality && index == (cardinality - 1)) {
-            cardinalityUpdated = cardinalityNext;
-        } else {
-            cardinalityUpdated = cardinality;
+            // if the conditions are right, we can bump the cardinality
+            if (cardinalityNext > cardinality && index == (cardinality - 1)) {
+                cardinalityUpdated = cardinalityNext;
+            } else {
+                cardinalityUpdated = cardinality;
+            }
+
+            indexUpdated = (index + 1) % cardinalityUpdated;
+            self[indexUpdated] = transform(last, blockTimestamp, tick, liquidity);
         }
-
-        indexUpdated = (index + 1) % cardinalityUpdated;
-        self[indexUpdated] = transform(last, blockTimestamp, tick, liquidity);
     }
 
     /// @notice Prepares the oracle array to store up to `next` observations
@@ -110,13 +116,15 @@ library Oracle {
         uint16 current,
         uint16 next
     ) internal returns (uint16) {
-        require(current > 0, 'I');
-        // no-op if the passed next value isn't greater than the current next value
-        if (next <= current) return current;
-        // store in each slot to prevent fresh SSTOREs in swaps
-        // this data will not be used because the initialized boolean is still false
-        for (uint16 i = current; i < next; i++) self[i].blockTimestamp = 1;
-        return next;
+        unchecked {
+            require(current > 0, 'I');
+            // no-op if the passed next value isn't greater than the current next value
+            if (next <= current) return current;
+            // store in each slot to prevent fresh SSTOREs in swaps
+            // this data will not be used because the initialized boolean is still false
+            for (uint16 i = current; i < next; i++) self[i].blockTimestamp = 1;
+            return next;
+        }
     }
 
     /// @notice comparator for 32-bit timestamps
@@ -130,13 +138,15 @@ library Oracle {
         uint32 a,
         uint32 b
     ) private pure returns (bool) {
-        // if there hasn't been overflow, no need to adjust
-        if (a <= time && b <= time) return a <= b;
+        unchecked {
+            // if there hasn't been overflow, no need to adjust
+            if (a <= time && b <= time) return a <= b;
 
-        uint256 aAdjusted = a > time ? a : a + 2**32;
-        uint256 bAdjusted = b > time ? b : b + 2**32;
+            uint256 aAdjusted = a > time ? a : a + 2**32;
+            uint256 bAdjusted = b > time ? b : b + 2**32;
 
-        return aAdjusted <= bAdjusted;
+            return aAdjusted <= bAdjusted;
+        }
     }
 
     /// @notice Fetches the observations beforeOrAt and atOrAfter a target, i.e. where [beforeOrAt, atOrAfter] is satisfied.
@@ -157,29 +167,31 @@ library Oracle {
         uint16 index,
         uint16 cardinality
     ) private view returns (Observation memory beforeOrAt, Observation memory atOrAfter) {
-        uint256 l = (index + 1) % cardinality; // oldest observation
-        uint256 r = l + cardinality - 1; // newest observation
-        uint256 i;
-        while (true) {
-            i = (l + r) / 2;
+        unchecked {
+            uint256 l = (index + 1) % cardinality; // oldest observation
+            uint256 r = l + cardinality - 1; // newest observation
+            uint256 i;
+            while (true) {
+                i = (l + r) / 2;
 
-            beforeOrAt = self[i % cardinality];
+                beforeOrAt = self[i % cardinality];
 
-            // we've landed on an uninitialized tick, keep searching higher (more recently)
-            if (!beforeOrAt.initialized) {
-                l = i + 1;
-                continue;
+                // we've landed on an uninitialized tick, keep searching higher (more recently)
+                if (!beforeOrAt.initialized) {
+                    l = i + 1;
+                    continue;
+                }
+
+                atOrAfter = self[(i + 1) % cardinality];
+
+                bool targetAtOrAfter = lte(time, beforeOrAt.blockTimestamp, target);
+
+                // check if we've found the answer!
+                if (targetAtOrAfter && lte(time, target, atOrAfter.blockTimestamp)) break;
+
+                if (!targetAtOrAfter) r = i - 1;
+                else l = i + 1;
             }
-
-            atOrAfter = self[(i + 1) % cardinality];
-
-            bool targetAtOrAfter = lte(time, beforeOrAt.blockTimestamp, target);
-
-            // check if we've found the answer!
-            if (targetAtOrAfter && lte(time, target, atOrAfter.blockTimestamp)) break;
-
-            if (!targetAtOrAfter) r = i - 1;
-            else l = i + 1;
         }
     }
 
@@ -204,29 +216,31 @@ library Oracle {
         uint128 liquidity,
         uint16 cardinality
     ) private view returns (Observation memory beforeOrAt, Observation memory atOrAfter) {
-        // optimistically set before to the newest observation
-        beforeOrAt = self[index];
+        unchecked {
+            // optimistically set before to the newest observation
+            beforeOrAt = self[index];
 
-        // if the target is chronologically at or after the newest observation, we can early return
-        if (lte(time, beforeOrAt.blockTimestamp, target)) {
-            if (beforeOrAt.blockTimestamp == target) {
-                // if newest observation equals target, we're in the same block, so we can ignore atOrAfter
-                return (beforeOrAt, atOrAfter);
-            } else {
-                // otherwise, we need to transform
-                return (beforeOrAt, transform(beforeOrAt, target, tick, liquidity));
+            // if the target is chronologically at or after the newest observation, we can early return
+            if (lte(time, beforeOrAt.blockTimestamp, target)) {
+                if (beforeOrAt.blockTimestamp == target) {
+                    // if newest observation equals target, we're in the same block, so we can ignore atOrAfter
+                    return (beforeOrAt, atOrAfter);
+                } else {
+                    // otherwise, we need to transform
+                    return (beforeOrAt, transform(beforeOrAt, target, tick, liquidity));
+                }
             }
+
+            // now, set before to the oldest observation
+            beforeOrAt = self[(index + 1) % cardinality];
+            if (!beforeOrAt.initialized) beforeOrAt = self[0];
+
+            // ensure that the target is chronologically at or after the oldest observation
+            require(lte(time, beforeOrAt.blockTimestamp, target), 'OLD');
+
+            // if we've reached this point, we have to binary search
+            return binarySearch(self, time, target, index, cardinality);
         }
-
-        // now, set before to the oldest observation
-        beforeOrAt = self[(index + 1) % cardinality];
-        if (!beforeOrAt.initialized) beforeOrAt = self[0];
-
-        // ensure that the target is chronologically at or after the oldest observation
-        require(lte(time, beforeOrAt.blockTimestamp, target), 'OLD');
-
-        // if we've reached this point, we have to binary search
-        return binarySearch(self, time, target, index, cardinality);
     }
 
     /// @dev Reverts if an observation at or before the desired observation timestamp does not exist.
@@ -251,38 +265,40 @@ library Oracle {
         uint128 liquidity,
         uint16 cardinality
     ) internal view returns (int56 tickCumulative, uint160 secondsPerLiquidityCumulativeX128) {
-        if (secondsAgo == 0) {
-            Observation memory last = self[index];
-            if (last.blockTimestamp != time) last = transform(last, time, tick, liquidity);
-            return (last.tickCumulative, last.secondsPerLiquidityCumulativeX128);
-        }
+        unchecked {
+            if (secondsAgo == 0) {
+                Observation memory last = self[index];
+                if (last.blockTimestamp != time) last = transform(last, time, tick, liquidity);
+                return (last.tickCumulative, last.secondsPerLiquidityCumulativeX128);
+            }
 
-        uint32 target = time - secondsAgo;
+            uint32 target = time - secondsAgo;
 
-        (Observation memory beforeOrAt, Observation memory atOrAfter) =
-            getSurroundingObservations(self, time, target, tick, index, liquidity, cardinality);
+            (Observation memory beforeOrAt, Observation memory atOrAfter) =
+                getSurroundingObservations(self, time, target, tick, index, liquidity, cardinality);
 
-        if (target == beforeOrAt.blockTimestamp) {
-            // we're at the left boundary
-            return (beforeOrAt.tickCumulative, beforeOrAt.secondsPerLiquidityCumulativeX128);
-        } else if (target == atOrAfter.blockTimestamp) {
-            // we're at the right boundary
-            return (atOrAfter.tickCumulative, atOrAfter.secondsPerLiquidityCumulativeX128);
-        } else {
-            // we're in the middle
-            uint32 observationTimeDelta = atOrAfter.blockTimestamp - beforeOrAt.blockTimestamp;
-            uint32 targetDelta = target - beforeOrAt.blockTimestamp;
-            return (
-                beforeOrAt.tickCumulative +
-                    ((atOrAfter.tickCumulative - beforeOrAt.tickCumulative) / observationTimeDelta) *
-                    targetDelta,
-                beforeOrAt.secondsPerLiquidityCumulativeX128 +
-                    uint160(
-                        (uint256(
-                            atOrAfter.secondsPerLiquidityCumulativeX128 - beforeOrAt.secondsPerLiquidityCumulativeX128
-                        ) * targetDelta) / observationTimeDelta
-                    )
-            );
+            if (target == beforeOrAt.blockTimestamp) {
+                // we're at the left boundary
+                return (beforeOrAt.tickCumulative, beforeOrAt.secondsPerLiquidityCumulativeX128);
+            } else if (target == atOrAfter.blockTimestamp) {
+                // we're at the right boundary
+                return (atOrAfter.tickCumulative, atOrAfter.secondsPerLiquidityCumulativeX128);
+            } else {
+                // we're in the middle
+                uint32 observationTimeDelta = atOrAfter.blockTimestamp - beforeOrAt.blockTimestamp;
+                uint32 targetDelta = target - beforeOrAt.blockTimestamp;
+                return (
+                    beforeOrAt.tickCumulative +
+                        ((atOrAfter.tickCumulative - beforeOrAt.tickCumulative) / int56(uint56(observationTimeDelta))) *
+                        int56(uint56(targetDelta)),
+                    beforeOrAt.secondsPerLiquidityCumulativeX128 +
+                        uint160(
+                            (uint256(
+                                atOrAfter.secondsPerLiquidityCumulativeX128 - beforeOrAt.secondsPerLiquidityCumulativeX128
+                            ) * targetDelta) / observationTimeDelta
+                        )
+                );
+            }
         }
     }
 
@@ -306,20 +322,22 @@ library Oracle {
         uint128 liquidity,
         uint16 cardinality
     ) internal view returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s) {
-        require(cardinality > 0, 'I');
+        unchecked {
+            require(cardinality > 0, 'I');
 
-        tickCumulatives = new int56[](secondsAgos.length);
-        secondsPerLiquidityCumulativeX128s = new uint160[](secondsAgos.length);
-        for (uint256 i = 0; i < secondsAgos.length; i++) {
-            (tickCumulatives[i], secondsPerLiquidityCumulativeX128s[i]) = observeSingle(
-                self,
-                time,
-                secondsAgos[i],
-                tick,
-                index,
-                liquidity,
-                cardinality
-            );
+            tickCumulatives = new int56[](secondsAgos.length);
+            secondsPerLiquidityCumulativeX128s = new uint160[](secondsAgos.length);
+            for (uint256 i = 0; i < secondsAgos.length; i++) {
+                (tickCumulatives[i], secondsPerLiquidityCumulativeX128s[i]) = observeSingle(
+                    self,
+                    time,
+                    secondsAgos[i],
+                    tick,
+                    index,
+                    liquidity,
+                    cardinality
+                );
+            }
         }
     }
 }

--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 import './FullMath.sol';
 import './FixedPoint128.sol';
@@ -47,42 +47,44 @@ library Position {
         uint256 feeGrowthInside0X128,
         uint256 feeGrowthInside1X128
     ) internal {
-        Info memory _self = self;
+        unchecked {
+            Info memory _self = self;
 
-        uint128 liquidityNext;
-        if (liquidityDelta == 0) {
-            require(_self.liquidity > 0, 'NP'); // disallow pokes for 0 liquidity positions
-            liquidityNext = _self.liquidity;
-        } else {
-            liquidityNext = LiquidityMath.addDelta(_self.liquidity, liquidityDelta);
-        }
+            uint128 liquidityNext;
+            if (liquidityDelta == 0) {
+                require(_self.liquidity > 0, 'NP'); // disallow pokes for 0 liquidity positions
+                liquidityNext = _self.liquidity;
+            } else {
+                liquidityNext = LiquidityMath.addDelta(_self.liquidity, liquidityDelta);
+            }
 
-        // calculate accumulated fees
-        uint128 tokensOwed0 =
-            uint128(
-                FullMath.mulDiv(
-                    feeGrowthInside0X128 - _self.feeGrowthInside0LastX128,
-                    _self.liquidity,
-                    FixedPoint128.Q128
-                )
-            );
-        uint128 tokensOwed1 =
-            uint128(
-                FullMath.mulDiv(
-                    feeGrowthInside1X128 - _self.feeGrowthInside1LastX128,
-                    _self.liquidity,
-                    FixedPoint128.Q128
-                )
-            );
+            // calculate accumulated fees
+            uint128 tokensOwed0 =
+                uint128(
+                    FullMath.mulDiv(
+                        feeGrowthInside0X128 - _self.feeGrowthInside0LastX128,
+                        _self.liquidity,
+                        FixedPoint128.Q128
+                    )
+                );
+            uint128 tokensOwed1 =
+                uint128(
+                    FullMath.mulDiv(
+                        feeGrowthInside1X128 - _self.feeGrowthInside1LastX128,
+                        _self.liquidity,
+                        FixedPoint128.Q128
+                    )
+                );
 
-        // update the position
-        if (liquidityDelta != 0) self.liquidity = liquidityNext;
-        self.feeGrowthInside0LastX128 = feeGrowthInside0X128;
-        self.feeGrowthInside1LastX128 = feeGrowthInside1X128;
-        if (tokensOwed0 > 0 || tokensOwed1 > 0) {
-            // overflow is acceptable, have to withdraw before you hit type(uint128).max fees
-            self.tokensOwed0 += tokensOwed0;
-            self.tokensOwed1 += tokensOwed1;
+            // update the position
+            if (liquidityDelta != 0) self.liquidity = liquidityNext;
+            self.feeGrowthInside0LastX128 = feeGrowthInside0X128;
+            self.feeGrowthInside1LastX128 = feeGrowthInside1X128;
+            if (tokensOwed0 > 0 || tokensOwed1 > 0) {
+                // overflow is acceptable, have to withdraw before you hit type(uint128).max fees
+                self.tokensOwed0 += tokensOwed0;
+                self.tokensOwed1 += tokensOwed1;
+            }
         }
     }
 }

--- a/contracts/libraries/SafeCast.sol
+++ b/contracts/libraries/SafeCast.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 /// @title Safe casting methods
 /// @notice Contains methods for safely casting between types
@@ -8,21 +8,27 @@ library SafeCast {
     /// @param y The uint256 to be downcasted
     /// @return z The downcasted integer, now type uint160
     function toUint160(uint256 y) internal pure returns (uint160 z) {
-        require((z = uint160(y)) == y);
+        unchecked {
+            require((z = uint160(y)) == y);
+        }
     }
 
     /// @notice Cast a int256 to a int128, revert on overflow or underflow
     /// @param y The int256 to be downcasted
     /// @return z The downcasted integer, now type int128
     function toInt128(int256 y) internal pure returns (int128 z) {
-        require((z = int128(y)) == y);
+        unchecked {
+            require((z = int128(y)) == y);
+        }
     }
 
     /// @notice Cast a uint256 to a int256, revert on overflow
     /// @param y The uint256 to be casted
     /// @return z The casted integer, now type int256
     function toInt256(uint256 y) internal pure returns (int256 z) {
-        require(y < 2**255);
-        z = int256(y);
+        unchecked {
+            require(y < 2**255);
+            z = int256(y);
+        }
     }
 }

--- a/contracts/libraries/SqrtPriceMath.sol
+++ b/contracts/libraries/SqrtPriceMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 import './LowGasSafeMath.sol';
 import './SafeCast.sol';
@@ -31,27 +31,29 @@ library SqrtPriceMath {
         uint256 amount,
         bool add
     ) internal pure returns (uint160) {
-        // we short circuit amount == 0 because the result is otherwise not guaranteed to equal the input price
-        if (amount == 0) return sqrtPX96;
-        uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+        unchecked {
+            // we short circuit amount == 0 because the result is otherwise not guaranteed to equal the input price
+            if (amount == 0) return sqrtPX96;
+            uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
 
-        if (add) {
-            uint256 product;
-            if ((product = amount * sqrtPX96) / amount == sqrtPX96) {
-                uint256 denominator = numerator1 + product;
-                if (denominator >= numerator1)
-                    // always fits in 160 bits
-                    return uint160(FullMath.mulDivRoundingUp(numerator1, sqrtPX96, denominator));
+            if (add) {
+                uint256 product;
+                if ((product = amount * sqrtPX96) / amount == sqrtPX96) {
+                    uint256 denominator = numerator1 + product;
+                    if (denominator >= numerator1)
+                        // always fits in 160 bits
+                        return uint160(FullMath.mulDivRoundingUp(numerator1, sqrtPX96, denominator));
+                }
+
+                return uint160(UnsafeMath.divRoundingUp(numerator1, (numerator1 / sqrtPX96).add(amount)));
+            } else {
+                uint256 product;
+                // if the product overflows, we know the denominator underflows
+                // in addition, we must check that the denominator does not underflow
+                require((product = amount * sqrtPX96) / amount == sqrtPX96 && numerator1 > product);
+                uint256 denominator = numerator1 - product;
+                return FullMath.mulDivRoundingUp(numerator1, sqrtPX96, denominator).toUint160();
             }
-
-            return uint160(UnsafeMath.divRoundingUp(numerator1, (numerator1 / sqrtPX96).add(amount)));
-        } else {
-            uint256 product;
-            // if the product overflows, we know the denominator underflows
-            // in addition, we must check that the denominator does not underflow
-            require((product = amount * sqrtPX96) / amount == sqrtPX96 && numerator1 > product);
-            uint256 denominator = numerator1 - product;
-            return FullMath.mulDivRoundingUp(numerator1, sqrtPX96, denominator).toUint160();
         }
     }
 
@@ -71,28 +73,30 @@ library SqrtPriceMath {
         uint256 amount,
         bool add
     ) internal pure returns (uint160) {
-        // if we're adding (subtracting), rounding down requires rounding the quotient down (up)
-        // in both cases, avoid a mulDiv for most inputs
-        if (add) {
-            uint256 quotient =
-                (
-                    amount <= type(uint160).max
-                        ? (amount << FixedPoint96.RESOLUTION) / liquidity
-                        : FullMath.mulDiv(amount, FixedPoint96.Q96, liquidity)
-                );
+        unchecked {
+            // if we're adding (subtracting), rounding down requires rounding the quotient down (up)
+            // in both cases, avoid a mulDiv for most inputs
+            if (add) {
+                uint256 quotient =
+                    (
+                        amount <= type(uint160).max
+                            ? (amount << FixedPoint96.RESOLUTION) / liquidity
+                            : FullMath.mulDiv(amount, FixedPoint96.Q96, liquidity)
+                    );
 
-            return uint256(sqrtPX96).add(quotient).toUint160();
-        } else {
-            uint256 quotient =
-                (
-                    amount <= type(uint160).max
-                        ? UnsafeMath.divRoundingUp(amount << FixedPoint96.RESOLUTION, liquidity)
-                        : FullMath.mulDivRoundingUp(amount, FixedPoint96.Q96, liquidity)
-                );
+                return uint256(sqrtPX96).add(quotient).toUint160();
+            } else {
+                uint256 quotient =
+                    (
+                        amount <= type(uint160).max
+                            ? UnsafeMath.divRoundingUp(amount << FixedPoint96.RESOLUTION, liquidity)
+                            : FullMath.mulDivRoundingUp(amount, FixedPoint96.Q96, liquidity)
+                    );
 
-            require(sqrtPX96 > quotient);
-            // always fits 160 bits
-            return uint160(sqrtPX96 - quotient);
+                require(sqrtPX96 > quotient);
+                // always fits 160 bits
+                return uint160(sqrtPX96 - quotient);
+            }
         }
     }
 
@@ -109,14 +113,16 @@ library SqrtPriceMath {
         uint256 amountIn,
         bool zeroForOne
     ) internal pure returns (uint160 sqrtQX96) {
-        require(sqrtPX96 > 0);
-        require(liquidity > 0);
+        unchecked {
+            require(sqrtPX96 > 0);
+            require(liquidity > 0);
 
-        // round to make sure that we don't pass the target price
-        return
-            zeroForOne
-                ? getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountIn, true)
-                : getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountIn, true);
+            // round to make sure that we don't pass the target price
+            return
+                zeroForOne
+                    ? getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountIn, true)
+                    : getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountIn, true);
+        }
     }
 
     /// @notice Gets the next sqrt price given an output amount of token0 or token1
@@ -132,14 +138,16 @@ library SqrtPriceMath {
         uint256 amountOut,
         bool zeroForOne
     ) internal pure returns (uint160 sqrtQX96) {
-        require(sqrtPX96 > 0);
-        require(liquidity > 0);
+        unchecked {
+            require(sqrtPX96 > 0);
+            require(liquidity > 0);
 
-        // round to make sure that we pass the target price
-        return
-            zeroForOne
-                ? getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountOut, false)
-                : getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountOut, false);
+            // round to make sure that we pass the target price
+            return
+                zeroForOne
+                    ? getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountOut, false)
+                    : getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountOut, false);
+        }
     }
 
     /// @notice Gets the amount0 delta between two prices
@@ -156,20 +164,22 @@ library SqrtPriceMath {
         uint128 liquidity,
         bool roundUp
     ) internal pure returns (uint256 amount0) {
-        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        unchecked {
+            if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
 
-        uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
-        uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
+            uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+            uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
 
-        require(sqrtRatioAX96 > 0);
+            require(sqrtRatioAX96 > 0);
 
-        return
-            roundUp
-                ? UnsafeMath.divRoundingUp(
-                    FullMath.mulDivRoundingUp(numerator1, numerator2, sqrtRatioBX96),
-                    sqrtRatioAX96
-                )
-                : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) / sqrtRatioAX96;
+            return
+                roundUp
+                    ? UnsafeMath.divRoundingUp(
+                        FullMath.mulDivRoundingUp(numerator1, numerator2, sqrtRatioBX96),
+                        sqrtRatioAX96
+                    )
+                    : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) / sqrtRatioAX96;
+        }
     }
 
     /// @notice Gets the amount1 delta between two prices
@@ -185,12 +195,14 @@ library SqrtPriceMath {
         uint128 liquidity,
         bool roundUp
     ) internal pure returns (uint256 amount1) {
-        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        unchecked {
+            if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
 
-        return
-            roundUp
-                ? FullMath.mulDivRoundingUp(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96)
-                : FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
+            return
+                roundUp
+                    ? FullMath.mulDivRoundingUp(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96)
+                    : FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
+        }
     }
 
     /// @notice Helper that gets signed token0 delta
@@ -203,10 +215,12 @@ library SqrtPriceMath {
         uint160 sqrtRatioBX96,
         int128 liquidity
     ) internal pure returns (int256 amount0) {
-        return
-            liquidity < 0
-                ? -getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
-                : getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+        unchecked {
+            return
+                liquidity < 0
+                    ? -getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+                    : getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+        }
     }
 
     /// @notice Helper that gets signed token1 delta
@@ -219,9 +233,11 @@ library SqrtPriceMath {
         uint160 sqrtRatioBX96,
         int128 liquidity
     ) internal pure returns (int256 amount1) {
-        return
-            liquidity < 0
-                ? -getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
-                : getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+        unchecked {
+            return
+                liquidity < 0
+                    ? -getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+                    : getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+        }
     }
 }

--- a/contracts/libraries/SwapMath.sol
+++ b/contracts/libraries/SwapMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 import './FullMath.sol';
 import './SqrtPriceMath.sol';
@@ -34,65 +34,67 @@ library SwapMath {
             uint256 feeAmount
         )
     {
-        bool zeroForOne = sqrtRatioCurrentX96 >= sqrtRatioTargetX96;
-        bool exactIn = amountRemaining >= 0;
+        unchecked {
+            bool zeroForOne = sqrtRatioCurrentX96 >= sqrtRatioTargetX96;
+            bool exactIn = amountRemaining >= 0;
 
-        if (exactIn) {
-            uint256 amountRemainingLessFee = FullMath.mulDiv(uint256(amountRemaining), 1e6 - feePips, 1e6);
-            amountIn = zeroForOne
-                ? SqrtPriceMath.getAmount0Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, true)
-                : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, true);
-            if (amountRemainingLessFee >= amountIn) sqrtRatioNextX96 = sqrtRatioTargetX96;
-            else
-                sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromInput(
-                    sqrtRatioCurrentX96,
-                    liquidity,
-                    amountRemainingLessFee,
-                    zeroForOne
-                );
-        } else {
-            amountOut = zeroForOne
-                ? SqrtPriceMath.getAmount1Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, false)
-                : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, false);
-            if (uint256(-amountRemaining) >= amountOut) sqrtRatioNextX96 = sqrtRatioTargetX96;
-            else
-                sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromOutput(
-                    sqrtRatioCurrentX96,
-                    liquidity,
-                    uint256(-amountRemaining),
-                    zeroForOne
-                );
-        }
+            if (exactIn) {
+                uint256 amountRemainingLessFee = FullMath.mulDiv(uint256(amountRemaining), 1e6 - feePips, 1e6);
+                amountIn = zeroForOne
+                    ? SqrtPriceMath.getAmount0Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, true)
+                    : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, true);
+                if (amountRemainingLessFee >= amountIn) sqrtRatioNextX96 = sqrtRatioTargetX96;
+                else
+                    sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromInput(
+                        sqrtRatioCurrentX96,
+                        liquidity,
+                        amountRemainingLessFee,
+                        zeroForOne
+                    );
+            } else {
+                amountOut = zeroForOne
+                    ? SqrtPriceMath.getAmount1Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, false)
+                    : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, false);
+                if (uint256(-amountRemaining) >= amountOut) sqrtRatioNextX96 = sqrtRatioTargetX96;
+                else
+                    sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromOutput(
+                        sqrtRatioCurrentX96,
+                        liquidity,
+                        uint256(-amountRemaining),
+                        zeroForOne
+                    );
+            }
 
-        bool max = sqrtRatioTargetX96 == sqrtRatioNextX96;
+            bool max = sqrtRatioTargetX96 == sqrtRatioNextX96;
 
-        // get the input/output amounts
-        if (zeroForOne) {
-            amountIn = max && exactIn
-                ? amountIn
-                : SqrtPriceMath.getAmount0Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, true);
-            amountOut = max && !exactIn
-                ? amountOut
-                : SqrtPriceMath.getAmount1Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, false);
-        } else {
-            amountIn = max && exactIn
-                ? amountIn
-                : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, true);
-            amountOut = max && !exactIn
-                ? amountOut
-                : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, false);
-        }
+            // get the input/output amounts
+            if (zeroForOne) {
+                amountIn = max && exactIn
+                    ? amountIn
+                    : SqrtPriceMath.getAmount0Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, true);
+                amountOut = max && !exactIn
+                    ? amountOut
+                    : SqrtPriceMath.getAmount1Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, false);
+            } else {
+                amountIn = max && exactIn
+                    ? amountIn
+                    : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, true);
+                amountOut = max && !exactIn
+                    ? amountOut
+                    : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, false);
+            }
 
-        // cap the output amount to not exceed the remaining output amount
-        if (!exactIn && amountOut > uint256(-amountRemaining)) {
-            amountOut = uint256(-amountRemaining);
-        }
+            // cap the output amount to not exceed the remaining output amount
+            if (!exactIn && amountOut > uint256(-amountRemaining)) {
+                amountOut = uint256(-amountRemaining);
+            }
 
-        if (exactIn && sqrtRatioNextX96 != sqrtRatioTargetX96) {
-            // we didn't reach the target, so take the remainder of the maximum input as fee
-            feeAmount = uint256(amountRemaining) - amountIn;
-        } else {
-            feeAmount = FullMath.mulDivRoundingUp(amountIn, feePips, 1e6 - feePips);
+            if (exactIn && sqrtRatioNextX96 != sqrtRatioTargetX96) {
+                // we didn't reach the target, so take the remainder of the maximum input as fee
+                feeAmount = uint256(amountRemaining) - amountIn;
+            } else {
+                feeAmount = FullMath.mulDivRoundingUp(amountIn, feePips, 1e6 - feePips);
+            }
         }
     }
 }

--- a/contracts/libraries/Tick.sol
+++ b/contracts/libraries/Tick.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 import './LowGasSafeMath.sol';
 import './SafeCast.sol';
@@ -42,10 +42,12 @@ library Tick {
     ///     e.g., a tickSpacing of 3 requires ticks to be initialized every 3rd tick i.e., ..., -6, -3, 0, 3, 6, ...
     /// @return The max liquidity per tick
     function tickSpacingToMaxLiquidityPerTick(int24 tickSpacing) internal pure returns (uint128) {
-        int24 minTick = (TickMath.MIN_TICK / tickSpacing) * tickSpacing;
-        int24 maxTick = (TickMath.MAX_TICK / tickSpacing) * tickSpacing;
-        uint24 numTicks = uint24((maxTick - minTick) / tickSpacing) + 1;
-        return type(uint128).max / numTicks;
+        unchecked {
+            int24 minTick = (TickMath.MIN_TICK / tickSpacing) * tickSpacing;
+            int24 maxTick = (TickMath.MAX_TICK / tickSpacing) * tickSpacing;
+            uint24 numTicks = uint24((maxTick - minTick) / tickSpacing) + 1;
+            return type(uint128).max / numTicks;
+        }
     }
 
     /// @notice Retrieves fee growth data
@@ -65,33 +67,35 @@ library Tick {
         uint256 feeGrowthGlobal0X128,
         uint256 feeGrowthGlobal1X128
     ) internal view returns (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) {
-        Info storage lower = self[tickLower];
-        Info storage upper = self[tickUpper];
+        unchecked {
+            Info storage lower = self[tickLower];
+            Info storage upper = self[tickUpper];
 
-        // calculate fee growth below
-        uint256 feeGrowthBelow0X128;
-        uint256 feeGrowthBelow1X128;
-        if (tickCurrent >= tickLower) {
-            feeGrowthBelow0X128 = lower.feeGrowthOutside0X128;
-            feeGrowthBelow1X128 = lower.feeGrowthOutside1X128;
-        } else {
-            feeGrowthBelow0X128 = feeGrowthGlobal0X128 - lower.feeGrowthOutside0X128;
-            feeGrowthBelow1X128 = feeGrowthGlobal1X128 - lower.feeGrowthOutside1X128;
+            // calculate fee growth below
+            uint256 feeGrowthBelow0X128;
+            uint256 feeGrowthBelow1X128;
+            if (tickCurrent >= tickLower) {
+                feeGrowthBelow0X128 = lower.feeGrowthOutside0X128;
+                feeGrowthBelow1X128 = lower.feeGrowthOutside1X128;
+            } else {
+                feeGrowthBelow0X128 = feeGrowthGlobal0X128 - lower.feeGrowthOutside0X128;
+                feeGrowthBelow1X128 = feeGrowthGlobal1X128 - lower.feeGrowthOutside1X128;
+            }
+
+            // calculate fee growth above
+            uint256 feeGrowthAbove0X128;
+            uint256 feeGrowthAbove1X128;
+            if (tickCurrent < tickUpper) {
+                feeGrowthAbove0X128 = upper.feeGrowthOutside0X128;
+                feeGrowthAbove1X128 = upper.feeGrowthOutside1X128;
+            } else {
+                feeGrowthAbove0X128 = feeGrowthGlobal0X128 - upper.feeGrowthOutside0X128;
+                feeGrowthAbove1X128 = feeGrowthGlobal1X128 - upper.feeGrowthOutside1X128;
+            }
+
+            feeGrowthInside0X128 = feeGrowthGlobal0X128 - feeGrowthBelow0X128 - feeGrowthAbove0X128;
+            feeGrowthInside1X128 = feeGrowthGlobal1X128 - feeGrowthBelow1X128 - feeGrowthAbove1X128;
         }
-
-        // calculate fee growth above
-        uint256 feeGrowthAbove0X128;
-        uint256 feeGrowthAbove1X128;
-        if (tickCurrent < tickUpper) {
-            feeGrowthAbove0X128 = upper.feeGrowthOutside0X128;
-            feeGrowthAbove1X128 = upper.feeGrowthOutside1X128;
-        } else {
-            feeGrowthAbove0X128 = feeGrowthGlobal0X128 - upper.feeGrowthOutside0X128;
-            feeGrowthAbove1X128 = feeGrowthGlobal1X128 - upper.feeGrowthOutside1X128;
-        }
-
-        feeGrowthInside0X128 = feeGrowthGlobal0X128 - feeGrowthBelow0X128 - feeGrowthAbove0X128;
-        feeGrowthInside1X128 = feeGrowthGlobal1X128 - feeGrowthBelow1X128 - feeGrowthAbove1X128;
     }
 
     /// @notice Updates a tick and returns true if the tick was flipped from initialized to uninitialized, or vice versa
@@ -120,33 +124,35 @@ library Tick {
         bool upper,
         uint128 maxLiquidity
     ) internal returns (bool flipped) {
-        Tick.Info storage info = self[tick];
+        unchecked {
+            Tick.Info storage info = self[tick];
 
-        uint128 liquidityGrossBefore = info.liquidityGross;
-        uint128 liquidityGrossAfter = LiquidityMath.addDelta(liquidityGrossBefore, liquidityDelta);
+            uint128 liquidityGrossBefore = info.liquidityGross;
+            uint128 liquidityGrossAfter = LiquidityMath.addDelta(liquidityGrossBefore, liquidityDelta);
 
-        require(liquidityGrossAfter <= maxLiquidity, 'LO');
+            require(liquidityGrossAfter <= maxLiquidity, 'LO');
 
-        flipped = (liquidityGrossAfter == 0) != (liquidityGrossBefore == 0);
+            flipped = (liquidityGrossAfter == 0) != (liquidityGrossBefore == 0);
 
-        if (liquidityGrossBefore == 0) {
-            // by convention, we assume that all growth before a tick was initialized happened _below_ the tick
-            if (tick <= tickCurrent) {
-                info.feeGrowthOutside0X128 = feeGrowthGlobal0X128;
-                info.feeGrowthOutside1X128 = feeGrowthGlobal1X128;
-                info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128;
-                info.tickCumulativeOutside = tickCumulative;
-                info.secondsOutside = time;
+            if (liquidityGrossBefore == 0) {
+                // by convention, we assume that all growth before a tick was initialized happened _below_ the tick
+                if (tick <= tickCurrent) {
+                    info.feeGrowthOutside0X128 = feeGrowthGlobal0X128;
+                    info.feeGrowthOutside1X128 = feeGrowthGlobal1X128;
+                    info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128;
+                    info.tickCumulativeOutside = tickCumulative;
+                    info.secondsOutside = time;
+                }
+                info.initialized = true;
             }
-            info.initialized = true;
+
+            info.liquidityGross = liquidityGrossAfter;
+
+            // when the lower (upper) tick is crossed left to right (right to left), liquidity must be added (removed)
+            info.liquidityNet = upper
+                ? int256(info.liquidityNet).sub(liquidityDelta).toInt128()
+                : int256(info.liquidityNet).add(liquidityDelta).toInt128();
         }
-
-        info.liquidityGross = liquidityGrossAfter;
-
-        // when the lower (upper) tick is crossed left to right (right to left), liquidity must be added (removed)
-        info.liquidityNet = upper
-            ? int256(info.liquidityNet).sub(liquidityDelta).toInt128()
-            : int256(info.liquidityNet).add(liquidityDelta).toInt128();
     }
 
     /// @notice Clears tick data
@@ -174,12 +180,14 @@ library Tick {
         int56 tickCumulative,
         uint32 time
     ) internal returns (int128 liquidityNet) {
-        Tick.Info storage info = self[tick];
-        info.feeGrowthOutside0X128 = feeGrowthGlobal0X128 - info.feeGrowthOutside0X128;
-        info.feeGrowthOutside1X128 = feeGrowthGlobal1X128 - info.feeGrowthOutside1X128;
-        info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128 - info.secondsPerLiquidityOutsideX128;
-        info.tickCumulativeOutside = tickCumulative - info.tickCumulativeOutside;
-        info.secondsOutside = time - info.secondsOutside;
-        liquidityNet = info.liquidityNet;
+        unchecked {
+            Tick.Info storage info = self[tick];
+            info.feeGrowthOutside0X128 = feeGrowthGlobal0X128 - info.feeGrowthOutside0X128;
+            info.feeGrowthOutside1X128 = feeGrowthGlobal1X128 - info.feeGrowthOutside1X128;
+            info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128 - info.secondsPerLiquidityOutsideX128;
+            info.tickCumulativeOutside = tickCumulative - info.tickCumulativeOutside;
+            info.secondsOutside = time - info.secondsOutside;
+            liquidityNet = info.liquidityNet;
+        }
     }
 }

--- a/contracts/libraries/TickBitmap.sol
+++ b/contracts/libraries/TickBitmap.sol
@@ -13,7 +13,7 @@ library TickBitmap {
     /// @return bitPos The bit position in the word where the flag is stored
     function position(int24 tick) private pure returns (int16 wordPos, uint8 bitPos) {
         wordPos = int16(tick >> 8);
-        bitPos = uint8(tick % 256);
+        bitPos = uint8(uint24(tick % 256));
     }
 
     /// @notice Flips the initialized state for a given tick from false to true, or vice versa
@@ -58,8 +58,8 @@ library TickBitmap {
             initialized = masked != 0;
             // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
             next = initialized
-                ? (compressed - int24(bitPos - BitMath.mostSignificantBit(masked))) * tickSpacing
-                : (compressed - int24(bitPos)) * tickSpacing;
+                ? (compressed - int24(uint24(bitPos - BitMath.mostSignificantBit(masked)))) * tickSpacing
+                : (compressed - int24(uint24(bitPos))) * tickSpacing;
         } else {
             // start from the word of the next tick, since the current tick state doesn't matter
             (int16 wordPos, uint8 bitPos) = position(compressed + 1);
@@ -71,8 +71,8 @@ library TickBitmap {
             initialized = masked != 0;
             // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
             next = initialized
-                ? (compressed + 1 + int24(BitMath.leastSignificantBit(masked) - bitPos)) * tickSpacing
-                : (compressed + 1 + int24(type(uint8).max - bitPos)) * tickSpacing;
+                ? (compressed + 1 + int24(uint24(BitMath.leastSignificantBit(masked) - bitPos))) * tickSpacing
+                : (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) * tickSpacing;
         }
     }
 }

--- a/contracts/libraries/TickBitmap.sol
+++ b/contracts/libraries/TickBitmap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 import './BitMath.sol';
 
@@ -25,10 +25,12 @@ library TickBitmap {
         int24 tick,
         int24 tickSpacing
     ) internal {
-        require(tick % tickSpacing == 0); // ensure that the tick is spaced
-        (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
-        uint256 mask = 1 << bitPos;
-        self[wordPos] ^= mask;
+        unchecked {
+            require(tick % tickSpacing == 0); // ensure that the tick is spaced
+            (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
+            uint256 mask = 1 << bitPos;
+            self[wordPos] ^= mask;
+        }
     }
 
     /// @notice Returns the next initialized tick contained in the same word (or adjacent word) as the tick that is either
@@ -45,34 +47,36 @@ library TickBitmap {
         int24 tickSpacing,
         bool lte
     ) internal view returns (int24 next, bool initialized) {
-        int24 compressed = tick / tickSpacing;
-        if (tick < 0 && tick % tickSpacing != 0) compressed--; // round towards negative infinity
+        unchecked {
+            int24 compressed = tick / tickSpacing;
+            if (tick < 0 && tick % tickSpacing != 0) compressed--; // round towards negative infinity
 
-        if (lte) {
-            (int16 wordPos, uint8 bitPos) = position(compressed);
-            // all the 1s at or to the right of the current bitPos
-            uint256 mask = (1 << bitPos) - 1 + (1 << bitPos);
-            uint256 masked = self[wordPos] & mask;
+            if (lte) {
+                (int16 wordPos, uint8 bitPos) = position(compressed);
+                // all the 1s at or to the right of the current bitPos
+                uint256 mask = (1 << bitPos) - 1 + (1 << bitPos);
+                uint256 masked = self[wordPos] & mask;
 
-            // if there are no initialized ticks to the right of or at the current tick, return rightmost in the word
-            initialized = masked != 0;
-            // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
-            next = initialized
-                ? (compressed - int24(uint24(bitPos - BitMath.mostSignificantBit(masked)))) * tickSpacing
-                : (compressed - int24(uint24(bitPos))) * tickSpacing;
-        } else {
-            // start from the word of the next tick, since the current tick state doesn't matter
-            (int16 wordPos, uint8 bitPos) = position(compressed + 1);
-            // all the 1s at or to the left of the bitPos
-            uint256 mask = ~((1 << bitPos) - 1);
-            uint256 masked = self[wordPos] & mask;
+                // if there are no initialized ticks to the right of or at the current tick, return rightmost in the word
+                initialized = masked != 0;
+                // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+                next = initialized
+                    ? (compressed - int24(uint24(bitPos - BitMath.mostSignificantBit(masked)))) * tickSpacing
+                    : (compressed - int24(uint24(bitPos))) * tickSpacing;
+            } else {
+                // start from the word of the next tick, since the current tick state doesn't matter
+                (int16 wordPos, uint8 bitPos) = position(compressed + 1);
+                // all the 1s at or to the left of the bitPos
+                uint256 mask = ~((1 << bitPos) - 1);
+                uint256 masked = self[wordPos] & mask;
 
-            // if there are no initialized ticks to the left of the current tick, return leftmost in the word
-            initialized = masked != 0;
-            // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
-            next = initialized
-                ? (compressed + 1 + int24(uint24(BitMath.leastSignificantBit(masked) - bitPos))) * tickSpacing
-                : (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) * tickSpacing;
+                // if there are no initialized ticks to the left of the current tick, return leftmost in the word
+                initialized = masked != 0;
+                // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+                next = initialized
+                    ? (compressed + 1 + int24(uint24(BitMath.leastSignificantBit(masked) - bitPos))) * tickSpacing
+                    : (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) * tickSpacing;
+            }
         }
     }
 }

--- a/contracts/libraries/TickMath.sol
+++ b/contracts/libraries/TickMath.sol
@@ -22,7 +22,7 @@ library TickMath {
     /// at the given tick
     function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
         uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
-        require(absTick <= uint256(MAX_TICK), 'T');
+        require(absTick <= uint256(uint24(MAX_TICK)), 'T');
 
         uint256 ratio = absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
         if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;

--- a/contracts/libraries/TickMath.sol
+++ b/contracts/libraries/TickMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 /// @title Math library for computing sqrt prices from ticks and vice versa
 /// @notice Computes sqrt price for ticks of size 1.0001, i.e. sqrt(1.0001^tick) as fixed point Q64.96 numbers. Supports
@@ -21,36 +21,38 @@ library TickMath {
     /// @return sqrtPriceX96 A Fixed point Q64.96 number representing the sqrt of the ratio of the two assets (token1/token0)
     /// at the given tick
     function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
-        uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
-        require(absTick <= uint256(uint24(MAX_TICK)), 'T');
+        unchecked {
+            uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
+            require(absTick <= uint256(uint24(MAX_TICK)), 'T');
 
-        uint256 ratio = absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
-        if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
-        if (absTick & 0x4 != 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
-        if (absTick & 0x8 != 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
-        if (absTick & 0x10 != 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644) >> 128;
-        if (absTick & 0x20 != 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
-        if (absTick & 0x40 != 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
-        if (absTick & 0x80 != 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
-        if (absTick & 0x100 != 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
-        if (absTick & 0x200 != 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
-        if (absTick & 0x400 != 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
-        if (absTick & 0x800 != 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
-        if (absTick & 0x1000 != 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
-        if (absTick & 0x2000 != 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
-        if (absTick & 0x4000 != 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
-        if (absTick & 0x8000 != 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6) >> 128;
-        if (absTick & 0x10000 != 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
-        if (absTick & 0x20000 != 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604) >> 128;
-        if (absTick & 0x40000 != 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98) >> 128;
-        if (absTick & 0x80000 != 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2) >> 128;
+            uint256 ratio = absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
+            if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
+            if (absTick & 0x4 != 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
+            if (absTick & 0x8 != 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
+            if (absTick & 0x10 != 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644) >> 128;
+            if (absTick & 0x20 != 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
+            if (absTick & 0x40 != 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
+            if (absTick & 0x80 != 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
+            if (absTick & 0x100 != 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
+            if (absTick & 0x200 != 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
+            if (absTick & 0x400 != 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
+            if (absTick & 0x800 != 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
+            if (absTick & 0x1000 != 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
+            if (absTick & 0x2000 != 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
+            if (absTick & 0x4000 != 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
+            if (absTick & 0x8000 != 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6) >> 128;
+            if (absTick & 0x10000 != 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
+            if (absTick & 0x20000 != 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604) >> 128;
+            if (absTick & 0x40000 != 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98) >> 128;
+            if (absTick & 0x80000 != 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2) >> 128;
 
-        if (tick > 0) ratio = type(uint256).max / ratio;
+            if (tick > 0) ratio = type(uint256).max / ratio;
 
-        // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
-        // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
-        // we round up in the division so getTickAtSqrtRatio of the output price is always consistent
-        sqrtPriceX96 = uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1));
+            // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
+            // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
+            // we round up in the division so getTickAtSqrtRatio of the output price is always consistent
+            sqrtPriceX96 = uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1));
+        }
     }
 
     /// @notice Calculates the greatest tick value such that getRatioAtTick(tick) <= ratio
@@ -59,147 +61,149 @@ library TickMath {
     /// @param sqrtPriceX96 The sqrt ratio for which to compute the tick as a Q64.96
     /// @return tick The greatest tick for which the ratio is less than or equal to the input ratio
     function getTickAtSqrtRatio(uint160 sqrtPriceX96) internal pure returns (int24 tick) {
-        // second inequality must be < because the price can never reach the price at the max tick
-        require(sqrtPriceX96 >= MIN_SQRT_RATIO && sqrtPriceX96 < MAX_SQRT_RATIO, 'R');
-        uint256 ratio = uint256(sqrtPriceX96) << 32;
+        unchecked {     
+            // second inequality must be < because the price can never reach the price at the max tick
+            require(sqrtPriceX96 >= MIN_SQRT_RATIO && sqrtPriceX96 < MAX_SQRT_RATIO, 'R');
+            uint256 ratio = uint256(sqrtPriceX96) << 32;
 
-        uint256 r = ratio;
-        uint256 msb = 0;
+            uint256 r = ratio;
+            uint256 msb = 0;
 
-        assembly {
-            let f := shl(7, gt(r, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
-            msb := or(msb, f)
-            r := shr(f, r)
-        }
-        assembly {
-            let f := shl(6, gt(r, 0xFFFFFFFFFFFFFFFF))
-            msb := or(msb, f)
-            r := shr(f, r)
-        }
-        assembly {
-            let f := shl(5, gt(r, 0xFFFFFFFF))
-            msb := or(msb, f)
-            r := shr(f, r)
-        }
-        assembly {
-            let f := shl(4, gt(r, 0xFFFF))
-            msb := or(msb, f)
-            r := shr(f, r)
-        }
-        assembly {
-            let f := shl(3, gt(r, 0xFF))
-            msb := or(msb, f)
-            r := shr(f, r)
-        }
-        assembly {
-            let f := shl(2, gt(r, 0xF))
-            msb := or(msb, f)
-            r := shr(f, r)
-        }
-        assembly {
-            let f := shl(1, gt(r, 0x3))
-            msb := or(msb, f)
-            r := shr(f, r)
-        }
-        assembly {
-            let f := gt(r, 0x1)
-            msb := or(msb, f)
-        }
+            assembly {
+                let f := shl(7, gt(r, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(6, gt(r, 0xFFFFFFFFFFFFFFFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(5, gt(r, 0xFFFFFFFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(4, gt(r, 0xFFFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(3, gt(r, 0xFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(2, gt(r, 0xF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(1, gt(r, 0x3))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := gt(r, 0x1)
+                msb := or(msb, f)
+            }
 
-        if (msb >= 128) r = ratio >> (msb - 127);
-        else r = ratio << (127 - msb);
+            if (msb >= 128) r = ratio >> (msb - 127);
+            else r = ratio << (127 - msb);
 
-        int256 log_2 = (int256(msb) - 128) << 64;
+            int256 log_2 = (int256(msb) - 128) << 64;
 
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(63, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(62, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(61, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(60, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(59, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(58, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(57, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(56, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(55, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(54, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(53, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(52, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(51, f))
-            r := shr(f, r)
-        }
-        assembly {
-            r := shr(127, mul(r, r))
-            let f := shr(128, r)
-            log_2 := or(log_2, shl(50, f))
-        }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(63, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(62, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(61, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(60, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(59, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(58, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(57, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(56, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(55, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(54, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(53, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(52, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(51, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(50, f))
+            }
 
-        int256 log_sqrt10001 = log_2 * 255738958999603826347141; // 128.128 number
+            int256 log_sqrt10001 = log_2 * 255738958999603826347141; // 128.128 number
 
-        int24 tickLow = int24((log_sqrt10001 - 3402992956809132418596140100660247210) >> 128);
-        int24 tickHi = int24((log_sqrt10001 + 291339464771989622907027621153398088495) >> 128);
+            int24 tickLow = int24((log_sqrt10001 - 3402992956809132418596140100660247210) >> 128);
+            int24 tickHi = int24((log_sqrt10001 + 291339464771989622907027621153398088495) >> 128);
 
-        tick = tickLow == tickHi ? tickLow : getSqrtRatioAtTick(tickHi) <= sqrtPriceX96 ? tickHi : tickLow;
+            tick = tickLow == tickHi ? tickLow : getSqrtRatioAtTick(tickHi) <= sqrtPriceX96 ? tickHi : tickLow;
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@uniswap/v3-core",
+  "name": "@134dd3v/uniswap-v3-core-0.8-support",
   "description": "🦄 Core smart contracts of Uniswap V3",
   "license": "BUSL-1.1",
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.0",
+  "version": "1.0.3",
   "homepage": "https://uniswap.org",
   "keywords": [
     "uniswap",
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Uniswap/uniswap-v3-core"
+    "url": "https://github.com/134dd3v/v3-core"
   },
   "files": [
     "contracts/interfaces",


### PR DESCRIPTION
Many of the current v3 core libraries do not work with solc 0.8 in their present state, bc of their dependency on FullMath, TickBitmap or TickMath which contain some code that gives compilation error on solc 0.8.

Though after the changes in this PR the `FullMath.spec.ts`, `TickBitmap.spec.ts` and `TickMath.spec.ts` tests pass. But the gas tests fail. Also it changes the UniswapV3Pool bytecode. Hence, the PR does not intend to be merged on main branch.

FWIW, it would be great if Uniswap can publish an official `@uniswap/v3-core-0.8-support` kind of package, so that projects can conveniently build on Uniswap V3 using solc 0.8, without copy-pasting files to their repo and modifying code (which could potentially violate licences).