### PR TITLE
Constrain FullMath pragma to <0.8.0

### DIFF
--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.0;
+pragma solidity >=0.4.0 <0.8.0;
 
 /// @title Contains 512-bit math functions
 /// @notice Facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision

--- a/contracts/libraries/Oracle.sol
+++ b/contracts/libraries/Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity >=0.5.0 <0.8.0;
 
 /// @title Oracle
 /// @notice Provides price and liquidity data useful for a wide variety of system designs

--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity >=0.5.0 <0.8.0;
 
 import './FullMath.sol';
 import './FixedPoint128.sol';

--- a/contracts/libraries/Tick.sol
+++ b/contracts/libraries/Tick.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity >=0.5.0 <0.8.0;
 
 import './LowGasSafeMath.sol';
 import './SafeCast.sol';

--- a/contracts/libraries/TickMath.sol
+++ b/contracts/libraries/TickMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.5.0 <0.8.0;
 
 /// @title Math library for computing sqrt prices from ticks and vice versa
 /// @notice Computes sqrt price for ticks of size 1.0001, i.e. sqrt(1.0001^tick) as fixed point Q64.96 numbers. Supports


### PR DESCRIPTION
In this PR I update the pragmas of FullMath and TicketMath to be `0.8.0`, as these do not compile with Solidity >=0.8.0. I also think this should be done out of safety, given FullMath relies on overflows and so, as I understand, will behave incorrectly if used with a solidity version >=0.8.0. 