### PR TITLE
Explicit conversions for Solidity 0.8.x compatibility

### DIFF
--- a/contracts/UniswapV3Pool.sol
+++ b/contracts/UniswapV3Pool.sol
@@ -468,7 +468,7 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
                     owner: recipient,
                     tickLower: tickLower,
                     tickUpper: tickUpper,
-                    liquidityDelta: int256(amount).toInt128()
+                    liquidityDelta: int256(uint256(amount)).toInt128()
                 })
             );
 
@@ -525,7 +525,7 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
                     owner: msg.sender,
                     tickLower: tickLower,
                     tickUpper: tickUpper,
-                    liquidityDelta: -int256(amount).toInt128()
+                    liquidityDelta: -int256(uint256(amount)).toInt128()
                 })
             );
 

--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -61,7 +61,7 @@ library FullMath {
         // Factor powers of two out of denominator
         // Compute largest power of two divisor of denominator.
         // Always >= 1.
-        uint256 twos = -denominator & denominator;
+        uint256 twos = uint256(-int256(denominator)) & denominator;
         // Divide denominator by power of two
         assembly {
             denominator := div(denominator, twos)

--- a/contracts/libraries/Oracle.sol
+++ b/contracts/libraries/Oracle.sol
@@ -37,7 +37,7 @@ library Oracle {
         return
             Observation({
                 blockTimestamp: blockTimestamp,
-                tickCumulative: last.tickCumulative + int56(tick) * delta,
+                tickCumulative: last.tickCumulative + int56(tick) * int56(uint56(delta)),
                 secondsPerLiquidityCumulativeX128: last.secondsPerLiquidityCumulativeX128 +
                     ((uint160(delta) << 128) / (liquidity > 0 ? liquidity : 1)),
                 initialized: true
@@ -275,7 +275,7 @@ library Oracle {
             return (
                 beforeOrAt.tickCumulative +
                     ((atOrAfter.tickCumulative - beforeOrAt.tickCumulative) / observationTimeDelta) *
-                    targetDelta,
+                    int56(uint56(targetDelta)),
                 beforeOrAt.secondsPerLiquidityCumulativeX128 +
                     uint160(
                         (uint256(

--- a/contracts/libraries/TickBitmap.sol
+++ b/contracts/libraries/TickBitmap.sol
@@ -13,7 +13,7 @@ library TickBitmap {
     /// @return bitPos The bit position in the word where the flag is stored
     function position(int24 tick) private pure returns (int16 wordPos, uint8 bitPos) {
         wordPos = int16(tick >> 8);
-        bitPos = uint8(tick % 256);
+        bitPos = uint8(uint24(tick % 256));
     }
 
     /// @notice Flips the initialized state for a given tick from false to true, or vice versa
@@ -58,8 +58,8 @@ library TickBitmap {
             initialized = masked != 0;
             // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
             next = initialized
-                ? (compressed - int24(bitPos - BitMath.mostSignificantBit(masked))) * tickSpacing
-                : (compressed - int24(bitPos)) * tickSpacing;
+                ? (compressed - int24(uint24(bitPos - BitMath.mostSignificantBit(masked)))) * tickSpacing
+                : (compressed - int24(uint24(bitPos))) * tickSpacing;
         } else {
             // start from the word of the next tick, since the current tick state doesn't matter
             (int16 wordPos, uint8 bitPos) = position(compressed + 1);
@@ -71,8 +71,8 @@ library TickBitmap {
             initialized = masked != 0;
             // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
             next = initialized
-                ? (compressed + 1 + int24(BitMath.leastSignificantBit(masked) - bitPos)) * tickSpacing
-                : (compressed + 1 + int24(type(uint8).max - bitPos)) * tickSpacing;
+                ? (compressed + 1 + int24(uint24(BitMath.leastSignificantBit(masked) - bitPos))) * tickSpacing
+                : (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) * tickSpacing;
         }
     }
 }

--- a/contracts/libraries/TickMath.sol
+++ b/contracts/libraries/TickMath.sol
@@ -22,7 +22,7 @@ library TickMath {
     /// at the given tick
     function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
         uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
-        require(absTick <= uint256(MAX_TICK), 'T');
+        require(absTick <= uint256(int256(MAX_TICK)), 'T');
 
         uint256 ratio = absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
         if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;

--- a/contracts/test/OracleEchidnaTest.sol
+++ b/contracts/test/OracleEchidnaTest.sol
@@ -61,7 +61,7 @@ contract OracleEchidnaTest {
 
         (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s) =
             oracle.observe(secondsAgos);
-        int56 timeWeightedTick = (tickCumulatives[1] - tickCumulatives[0]) / timeElapsed;
+        int56 timeWeightedTick = (tickCumulatives[1] - tickCumulatives[0]) / int56(uint56(timeElapsed));
         uint256 timeWeightedHarmonicMeanLiquidity =
             (uint256(timeElapsed) * type(uint160).max) /
                 (uint256(secondsPerLiquidityCumulativeX128s[1] - secondsPerLiquidityCumulativeX128s[0]) << 32);
@@ -107,7 +107,7 @@ contract OracleEchidnaTest {
 
         uint32 timeElapsed = blockTimestamp1 - blockTimestamp0;
         assert(timeElapsed > 0);
-        assert((tickCumulative1 - tickCumulative0) % timeElapsed == 0);
+        assert((tickCumulative1 - tickCumulative0) % int56(uint56(timeElapsed)) == 0);
     }
 
     function checkTimeWeightedAveragesAlwaysFitsType(uint32 secondsAgo) external view {
@@ -121,8 +121,8 @@ contract OracleEchidnaTest {
 
         // compute the time weighted tick, rounded towards negative infinity
         int56 numerator = tickCumulatives[1] - tickCumulatives[0];
-        int56 timeWeightedTick = numerator / int56(secondsAgo);
-        if (numerator < 0 && numerator % int56(secondsAgo) != 0) {
+        int56 timeWeightedTick = numerator / int56(uint56(secondsAgo));
+        if (numerator < 0 && numerator % int56(uint56(secondsAgo)) != 0) {
             timeWeightedTick--;
         }
 

--- a/contracts/test/TickEchidnaTest.sol
+++ b/contracts/test/TickEchidnaTest.sol
@@ -20,7 +20,7 @@ contract TickEchidnaTest {
         // divisibility
         assert((maxTick - minTick) % tickSpacing == 0);
 
-        uint256 numTicks = uint256((maxTick - minTick) / tickSpacing) + 1;
+        uint256 numTicks = uint256(int256((maxTick - minTick) / tickSpacing)) + 1;
         // max liquidity at every tick is less than the cap
         assert(uint256(maxLiquidityPerTick) * numTicks <= type(uint128).max);
     }


### PR DESCRIPTION
This PR changes integer conversions from implicit to explicit ones in several places where implicit ones are no longer allowed in Solidity 0.8. The change does not change behavior, just makes the code (almost) compile on both 0.7.6 and 0.8.11.

I'm trying to compile Uniswap using the latest Solidity compiler so that it can be included in the suite of external tests. We use these tests to ensure that new releases do not break existing projects. The PR on its own is not enough to make the project compatible with 0.8.x but it reduces the number of changes needed and has no real downsides.

The PR omits [one place in `Oracle.sol` where a conversion is also needed](https://github.com/Uniswap/v3-core/blob/9161f9ae4aaa109f7efdff84f1df8d4bc8bfd042/contracts/libraries/Oracle.sol#L277):
```diff
-((atOrAfter.tickCumulative - beforeOrAt.tickCumulative) / observationTimeDelta) *
+((atOrAfter.tickCumulative - beforeOrAt.tickCumulative) / int56(uint56(observationTimeDelta))) *
```
I'm omitting it because this one does have a downside: is not free. It results in the compiler inserting an extra `SIGNEXTEND` instruction that in the end does not get optimized out and increases the cost by 12 gas. I tried to compensate for it by optimizing the code around it but while it improves the cost in some tests, for some reason it makes others more expensive.