### PR TITLE
Optimized Code for NoDelegateCall.sol

### DIFF
--- a/contracts/NoDelegateCall.sol
+++ b/contracts/NoDelegateCall.sol
@@ -1,27 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.7.6;
+pragma solidity 0.7.6;
 
 /// @title Prevents delegatecall to a contract
 /// @notice Base contract that provides a modifier for preventing delegatecall to methods in a child contract
 abstract contract NoDelegateCall {
-    /// @dev The original address of this contract
-    address private immutable original;
+    constructor() public {
+        // Store the address of the contract in a variable
+        address original = address(this);
 
-    constructor() {
-        // Immutables are computed in the init code of the contract, and then inlined into the deployed bytecode.
-        // In other words, this variable won't change when it's checked at runtime.
-        original = address(this);
-    }
-
-    /// @dev Private method is used instead of inlining into modifier because modifiers are copied into each method,
-    ///     and the use of immutable means the address bytes are copied in every place the modifier is used.
-    function checkNotDelegateCall() private view {
-        require(address(this) == original);
-    }
-
-    /// @notice Prevents delegatecall into the modified method
-    modifier noDelegateCall() {
-        checkNotDelegateCall();
-        _;
+        // Define a modifier that checks if the current contract's
+        // address matches the original address
+        modifier noDelegateCall() {
+            require(address(this) == original, "Delegate call detected");
+            _;
+        }
     }
 }


### PR DESCRIPTION
In this version, the **checkNotDelegateCall()** function has been removed and its functionality has been incorporated into the **noDelegateCall()** modifier. This reduces the amount of code and makes the contract more efficient.

I would love to contribute more to Uniswap code.
Cheers!