### PR TITLE
avoid duplicated comparison between sqrtRatioNextX96 and sqrtRatioTar…

### DIFF
--- a/contracts/libraries/SwapMath.sol
+++ b/contracts/libraries/SwapMath.sol
@@ -88,7 +88,7 @@ library SwapMath {
             amountOut = uint256(-amountRemaining);
         }
 
-        if (exactIn && sqrtRatioNextX96 != sqrtRatioTargetX96) {
+        if (exactIn && !max) {
             // we didn't reach the target, so take the remainder of the maximum input as fee
             feeAmount = uint256(amountRemaining) - amountIn;
         } else {


### PR DESCRIPTION
sqrtRatioNextX96 and sqrtRatioTargetX96 has already been compared in above code. Do not need to compare them again.