### PR TITLE
change memory to calldata

### DIFF
--- a/contracts/libraries/Oracle.sol
+++ b/contracts/libraries/Oracle.sol
@@ -28,7 +28,7 @@ library Oracle {
     /// @param liquidity The total in-range liquidity at the time of the new observation
     /// @return Observation The newly populated observation
     function transform(
-        Observation memory last,
+        Observation calldata last,
         uint32 blockTimestamp,
         int24 tick,
         uint128 liquidity


### PR DESCRIPTION
Changing the data location of function parameters from memory to calldata can save much gas.
In the following example, test4 saves about 955 units of gas.

```
    function test3(uint256[] memory amounts) public {
        uint256 amount = amounts[0];
    }

    function test4(uint256[] calldata amounts) public {
        uint256 amount = amounts[0];
    }
```