### PR TITLE
move loop invariant variables out from loop to save gas

### DIFF
--- a/contracts/UniswapV3Pool.sol
+++ b/contracts/UniswapV3Pool.sol
@@ -639,7 +639,6 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
 
         // continue swapping as long as we haven't used the entire input/output and haven't reached the price limit
         StepComputations memory step;
-        uint256 delta;
         while (state.amountSpecifiedRemaining != 0 && state.sqrtPriceX96 != sqrtPriceLimitX96) {
 
             step.sqrtPriceStartX96 = state.sqrtPriceX96;
@@ -681,7 +680,7 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
 
             // if the protocol fee is on, calculate how much is owed, decrement feeAmount, and increment protocolFee
             if (cache.feeProtocol > 0) {
-                delta = step.feeAmount / cache.feeProtocol;
+                uint256 delta = step.feeAmount / cache.feeProtocol;
                 step.feeAmount -= delta;
                 state.protocolFee += uint128(delta);
             }

--- a/contracts/UniswapV3Pool.sol
+++ b/contracts/UniswapV3Pool.sol
@@ -638,8 +638,9 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
             });
 
         // continue swapping as long as we haven't used the entire input/output and haven't reached the price limit
+        StepComputations memory step;
+        uint256 delta;
         while (state.amountSpecifiedRemaining != 0 && state.sqrtPriceX96 != sqrtPriceLimitX96) {
-            StepComputations memory step;
 
             step.sqrtPriceStartX96 = state.sqrtPriceX96;
 
@@ -680,7 +681,7 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
 
             // if the protocol fee is on, calculate how much is owed, decrement feeAmount, and increment protocolFee
             if (cache.feeProtocol > 0) {
-                uint256 delta = step.feeAmount / cache.feeProtocol;
+                delta = step.feeAmount / cache.feeProtocol;
                 step.feeAmount -= delta;
                 state.protocolFee += uint128(delta);
             }

--- a/contracts/libraries/Oracle.sol
+++ b/contracts/libraries/Oracle.sol
@@ -308,9 +308,10 @@ library Oracle {
     ) internal view returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s) {
         require(cardinality > 0, 'I');
 
-        tickCumulatives = new int56[](secondsAgos.length);
-        secondsPerLiquidityCumulativeX128s = new uint160[](secondsAgos.length);
-        for (uint256 i = 0; i < secondsAgos.length; i++) {
+        uint256 len = secondsAgos.length;
+        tickCumulatives = new int56[](len);
+        secondsPerLiquidityCumulativeX128s = new uint160[](len);
+        for (uint256 i = 0; i < len; i++) {
             (tickCumulatives[i], secondsPerLiquidityCumulativeX128s[i]) = observeSingle(
                 self,
                 time,

--- a/contracts/libraries/Oracle.sol
+++ b/contracts/libraries/Oracle.sol
@@ -160,6 +160,7 @@ library Oracle {
         uint256 l = (index + 1) % cardinality; // oldest observation
         uint256 r = l + cardinality - 1; // newest observation
         uint256 i;
+        bool targetAtOrAfter;
         while (true) {
             i = (l + r) / 2;
 
@@ -173,7 +174,7 @@ library Oracle {
 
             atOrAfter = self[(i + 1) % cardinality];
 
-            bool targetAtOrAfter = lte(time, beforeOrAt.blockTimestamp, target);
+            targetAtOrAfter = lte(time, beforeOrAt.blockTimestamp, target);
 
             // check if we've found the answer!
             if (targetAtOrAfter && lte(time, target, atOrAfter.blockTimestamp)) break;


### PR DESCRIPTION
Moving loop invariant codes out from loop can save gas.
In the following demo, it can save 765 units of gas when the length of ```arr``` is 100.

```
    function test1(uint256[] calldata arr) public {     
        for(uint256 i = 0; i < arr.length; i++) {
        }
    }

    function test2(uint256[] calldata arr) public {
        uint256 len = arr.length;
        for(uint256 i = 0; i < len; i++) {
        }
    }
```