### PR TITLE
Fixed Typos in function swap's doc string

### DIFF
--- a/contracts/interfaces/pool/IUniswapV3PoolActions.sol
+++ b/contracts/interfaces/pool/IUniswapV3PoolActions.sol
@@ -68,7 +68,7 @@ interface IUniswapV3PoolActions {
     /// @param zeroForOne The direction of the swap, true for token0 to token1, false for token1 to token0
     /// @param amountSpecified The amount of the swap, which implicitly configures the swap as exact input (positive), or exact output (negative)
     /// @param sqrtPriceLimitX96 The Q64.96 sqrt price limit. If zero for one, the price cannot be less than this
-    /// value after the swap. If one for zero, the price cannot be greater than this value after the swap
+    /// value after the swap. If not one for zero, the price cannot be greater than this value after the swap
     /// @param data Any data to be passed through to the callback
     /// @return amount0 The delta of the balance of token0 of the pool, exact when negative, minimum when positive
     /// @return amount1 The delta of the balance of token1 of the pool, exact when negative, minimum when positive


### PR DESCRIPTION
Fixed Typos in function swap's doc string.