### PR TITLE
docs: fix incorrect Natspec param name for `CollectProtocol` event

### DIFF
--- a/contracts/interfaces/pool/IUniswapV3PoolEvents.sol
+++ b/contracts/interfaces/pool/IUniswapV3PoolEvents.sol
@@ -116,6 +116,6 @@ interface IUniswapV3PoolEvents {
     /// @param sender The address that collects the protocol fees
     /// @param recipient The address that receives the collected protocol fees
     /// @param amount0 The amount of token0 protocol fees that is withdrawn
-    /// @param amount0 The amount of token1 protocol fees that is withdrawn
+    /// @param amount1 The amount of token1 protocol fees that is withdrawn
     event CollectProtocol(address indexed sender, address indexed recipient, uint128 amount0, uint128 amount1);
 }


### PR DESCRIPTION
Fix incorrect name in Natspec tag `@param` for `CollectProtocol` event

- `@param amount0` ❌ 

should be

- `@param amount1` ✅ 

https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/interfaces/pool/IUniswapV3PoolEvents.sol#L118-L120
