### PR TITLE
change SLOAD to MLOAD to save gas

### DIFF
--- a/contracts/UniswapV3Factory.sol
+++ b/contracts/UniswapV3Factory.sol
@@ -52,8 +52,9 @@ contract UniswapV3Factory is IUniswapV3Factory, UniswapV3PoolDeployer, NoDelegat
 
     /// @inheritdoc IUniswapV3Factory
     function setOwner(address _owner) external override {
-        require(msg.sender == owner);
-        emit OwnerChanged(owner, _owner);
+        address owner_local = owner;
+        require(msg.sender == owner_local);
+        emit OwnerChanged(owner_local, _owner);
         owner = _owner;
     }
 

--- a/contracts/UniswapV3Pool.sol
+++ b/contracts/UniswapV3Pool.sol
@@ -176,8 +176,8 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
         uint32 secondsOutsideUpper;
 
         {
-            Tick.Info storage lower = ticks[tickLower];
-            Tick.Info storage upper = ticks[tickUpper];
+            Tick.Info memory lower = ticks[tickLower];
+            Tick.Info memory upper = ticks[tickUpper];
             bool initializedLower;
             (tickCumulativeLower, secondsPerLiquidityOutsideLowerX128, secondsOutsideLower, initializedLower) = (
                 lower.tickCumulativeOutside,

--- a/contracts/UniswapV3Pool.sol
+++ b/contracts/UniswapV3Pool.sol
@@ -176,8 +176,8 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
         uint32 secondsOutsideUpper;
 
         {
-            Tick.Info memory lower = ticks[tickLower];
-            Tick.Info memory upper = ticks[tickUpper];
+            Tick.Info storage lower = ticks[tickLower];
+            Tick.Info storage upper = ticks[tickUpper];
             bool initializedLower;
             (tickCumulativeLower, secondsPerLiquidityOutsideLowerX128, secondsOutsideLower, initializedLower) = (
                 lower.tickCumulativeOutside,

--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -81,8 +81,8 @@ library Position {
         self.feeGrowthInside1LastX128 = feeGrowthInside1X128;
         if (tokensOwed0 > 0 || tokensOwed1 > 0) {
             // overflow is acceptable, have to withdraw before you hit type(uint128).max fees
-            self.tokensOwed0 += tokensOwed0;
-            self.tokensOwed1 += tokensOwed1;
+            self.tokensOwed0 = _self.tokensOwed0 + tokensOwed0;
+            self.tokensOwed1 = _self.tokensOwed1 + tokensOwed1;
         }
     }
 }

--- a/contracts/libraries/Tick.sol
+++ b/contracts/libraries/Tick.sol
@@ -142,12 +142,11 @@ library Tick {
         }
 
         info.liquidityGross = liquidityGrossAfter;
-        int128 liquidityNetBefore = info.liquidityNet;
 
         // when the lower (upper) tick is crossed left to right (right to left), liquidity must be added (removed)
         info.liquidityNet = upper
-            ? int256(liquidityNetBefore).sub(liquidityDelta).toInt128()
-            : int256(liquidityNetBefore).add(liquidityDelta).toInt128();
+            ? int256(info.liquidityNet).sub(liquidityDelta).toInt128()
+            : int256(info.liquidityNet).add(liquidityDelta).toInt128();
     }
 
     /// @notice Clears tick data
@@ -176,12 +175,11 @@ library Tick {
         uint32 time
     ) internal returns (int128 liquidityNet) {
         Tick.Info storage info = self[tick];
-        Tick.Info memory info_memory = info;
-        info.feeGrowthOutside0X128 = feeGrowthGlobal0X128 - info_memory.feeGrowthOutside0X128;
-        info.feeGrowthOutside1X128 = feeGrowthGlobal1X128 - info_memory.feeGrowthOutside1X128;
-        info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128 - info_memory.secondsPerLiquidityOutsideX128;
-        info.tickCumulativeOutside = tickCumulative - info_memory.tickCumulativeOutside;
-        info.secondsOutside = time - info_memory.secondsOutside;
-        liquidityNet = info_memory.liquidityNet;
+        info.feeGrowthOutside0X128 = feeGrowthGlobal0X128 - info.feeGrowthOutside0X128;
+        info.feeGrowthOutside1X128 = feeGrowthGlobal1X128 - info.feeGrowthOutside1X128;
+        info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128 - info.secondsPerLiquidityOutsideX128;
+        info.tickCumulativeOutside = tickCumulative - info.tickCumulativeOutside;
+        info.secondsOutside = time - info.secondsOutside;
+        liquidityNet = info.liquidityNet;
     }
 }

--- a/contracts/libraries/Tick.sol
+++ b/contracts/libraries/Tick.sol
@@ -175,11 +175,12 @@ library Tick {
         uint32 time
     ) internal returns (int128 liquidityNet) {
         Tick.Info storage info = self[tick];
-        info.feeGrowthOutside0X128 = feeGrowthGlobal0X128 - info.feeGrowthOutside0X128;
-        info.feeGrowthOutside1X128 = feeGrowthGlobal1X128 - info.feeGrowthOutside1X128;
-        info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128 - info.secondsPerLiquidityOutsideX128;
-        info.tickCumulativeOutside = tickCumulative - info.tickCumulativeOutside;
-        info.secondsOutside = time - info.secondsOutside;
-        liquidityNet = info.liquidityNet;
+        Tick.Info memory info_memory = info;
+        info.feeGrowthOutside0X128 = feeGrowthGlobal0X128 - info_memory.feeGrowthOutside0X128;
+        info.feeGrowthOutside1X128 = feeGrowthGlobal1X128 - info_memory.feeGrowthOutside1X128;
+        info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128 - info_memory.secondsPerLiquidityOutsideX128;
+        info.tickCumulativeOutside = tickCumulative - info_memory.tickCumulativeOutside;
+        info.secondsOutside = time - info_memory.secondsOutside;
+        liquidityNet = info_memory.liquidityNet;
     }
 }

--- a/contracts/libraries/Tick.sol
+++ b/contracts/libraries/Tick.sol
@@ -65,8 +65,8 @@ library Tick {
         uint256 feeGrowthGlobal0X128,
         uint256 feeGrowthGlobal1X128
     ) internal view returns (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) {
-        Info memory lower = self[tickLower];
-        Info memory upper = self[tickUpper];
+        Info storage lower = self[tickLower];
+        Info storage upper = self[tickUpper];
 
         // calculate fee growth below
         uint256 feeGrowthBelow0X128;

--- a/contracts/libraries/Tick.sol
+++ b/contracts/libraries/Tick.sol
@@ -65,8 +65,8 @@ library Tick {
         uint256 feeGrowthGlobal0X128,
         uint256 feeGrowthGlobal1X128
     ) internal view returns (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) {
-        Info storage lower = self[tickLower];
-        Info storage upper = self[tickUpper];
+        Info memory lower = self[tickLower];
+        Info memory upper = self[tickUpper];
 
         // calculate fee growth below
         uint256 feeGrowthBelow0X128;
@@ -142,11 +142,12 @@ library Tick {
         }
 
         info.liquidityGross = liquidityGrossAfter;
+        int128 liquidityNetBefore = info.liquidityNet;
 
         // when the lower (upper) tick is crossed left to right (right to left), liquidity must be added (removed)
         info.liquidityNet = upper
-            ? int256(info.liquidityNet).sub(liquidityDelta).toInt128()
-            : int256(info.liquidityNet).add(liquidityDelta).toInt128();
+            ? int256(liquidityNetBefore).sub(liquidityDelta).toInt128()
+            : int256(liquidityNetBefore).add(liquidityDelta).toInt128();
     }
 
     /// @notice Clears tick data


### PR DESCRIPTION
Reading a state variable costs more gas than reading a local variable. If a state variable is read multiple times, it saves gas to cache the variable as a local variable and then read the local variable.