### PR TITLE
Update UniswapV3Pool.sol

### DIFF
--- a/contracts/UniswapV3Pool.sol
+++ b/contracts/UniswapV3Pool.sol
@@ -468,7 +468,7 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
                     owner: recipient,
                     tickLower: tickLower,
                     tickUpper: tickUpper,
-                    liquidityDelta: int256(amount).toInt128()
+                    liquidityDelta: int256(uint256(amount)).toInt128()
                 })
             );
 


### PR DESCRIPTION
  liquidityDelta: int256(uint256(amount)).toInt128 
for mint
was getting Explicit type conversion not allowed from "uint128" to "int256". for solidity  ^0.8.19