### PR TITLE
Update mask calculation on TickBitmap::nextInitializedTickWithinOneWord

### DIFF
--- a/contracts/libraries/TickBitmap.sol
+++ b/contracts/libraries/TickBitmap.sol
@@ -51,7 +51,7 @@ library TickBitmap {
         if (lte) {
             (int16 wordPos, uint8 bitPos) = position(compressed);
             // all the 1s at or to the right of the current bitPos
-            uint256 mask = (1 << bitPos) - 1 + (1 << bitPos);
+            uint256 mask = (1 << (bitPos + 1)) - 1;
             uint256 masked = self[wordPos] & mask;
 
             // if there are no initialized ticks to the right of or at the current tick, return rightmost in the word


### PR DESCRIPTION
I calculated mask opcode by opcode and realized that calculating mask in this way is slightly gas-efficient.
Based on these test cases 
```solidity 
function testMaskAreEqual() public view {
    uint8 bitPos = 8;
    // mask1 function is the calculation that you are currently using.
    uint256 mask1_calculated = mask_cal.mask1(bitPos);
    // mask2 function is the efficient way.
    uint256 mask2_calculated = mask_cal.mask2(bitPos);
    assertEq(mask1_calculated, mask2_calculated);
}
    
function testMask1() public view {
    uint8 bitPos = 8;
    uint256 mask = mask_cal.mask1(bitPos);
    console.log(mask);
}
    
function testMask2() public view {
    uint8 bitPos = 8;
    uint256 mask = mask_cal.mask2(bitPos);
    console.log(mask);
}
```
<details>
<summary> The actual functions' code </summary>

```solidity
function mask1(uint8 bitPos) external pure returns(uint256 mask) {
    mask = (1 << bitPos) - 1 + (1 << bitPos);
}
    
function mask2(uint8 bitPos) external pure returns(uint256 mask) {
    mask = (1 << (bitPos+1)) - 1;
}
```

</details>


And the result is (via foundry):

![result](https://github.com/Uniswap/v3-core/assets/77713904/aa1b72c5-7427-429b-8791-4849b7110f59)

As you can see, there is a small difference in gas consumption between these two functions.
