### PR TITLE
fix TickBitmap, SwapMath, Oracle: replace "if (A && B)" to save gas fee issue

### DIFF
--- a/contracts/libraries/Oracle.sol
+++ b/contracts/libraries/Oracle.sol
@@ -90,8 +90,10 @@ library Oracle {
         if (last.blockTimestamp == blockTimestamp) return (index, cardinality);
 
         // if the conditions are right, we can bump the cardinality
-        if (cardinalityNext > cardinality && index == (cardinality - 1)) {
-            cardinalityUpdated = cardinalityNext;
+        if (cardinalityNext > cardinality) {
+            if (index == (cardinality - 1)) {
+                cardinalityUpdated = cardinalityNext;
+            }
         } else {
             cardinalityUpdated = cardinality;
         }
@@ -131,7 +133,11 @@ library Oracle {
         uint32 b
     ) private pure returns (bool) {
         // if there hasn't been overflow, no need to adjust
-        if (a <= time && b <= time) return a <= b;
+        if (a <= time) {
+            if (b <= time) {
+                return a <= b;
+            }
+        }
 
         uint256 aAdjusted = a > time ? a : a + 2**32;
         uint256 bAdjusted = b > time ? b : b + 2**32;
@@ -176,7 +182,11 @@ library Oracle {
             bool targetAtOrAfter = lte(time, beforeOrAt.blockTimestamp, target);
 
             // check if we've found the answer!
-            if (targetAtOrAfter && lte(time, target, atOrAfter.blockTimestamp)) break;
+            if (targetAtOrAfter) {
+                if (lte(time, target, atOrAfter.blockTimestamp)) {
+                    break;
+                }
+            }
 
             if (!targetAtOrAfter) r = i - 1;
             else l = i + 1;

--- a/contracts/libraries/SwapMath.sol
+++ b/contracts/libraries/SwapMath.sol
@@ -84,13 +84,17 @@ library SwapMath {
         }
 
         // cap the output amount to not exceed the remaining output amount
-        if (!exactIn && amountOut > uint256(-amountRemaining)) {
-            amountOut = uint256(-amountRemaining);
+        if (!exactIn) {
+            if (amountOut > uint256(-amountRemaining)) {
+                amountOut = uint256(-amountRemaining);
+            }
         }
 
-        if (exactIn && sqrtRatioNextX96 != sqrtRatioTargetX96) {
-            // we didn't reach the target, so take the remainder of the maximum input as fee
-            feeAmount = uint256(amountRemaining) - amountIn;
+        if (exactIn) {
+            if (sqrtRatioNextX96 != sqrtRatioTargetX96) {
+                // we didn't reach the target, so take the remainder of the maximum input as fee
+                feeAmount = uint256(amountRemaining) - amountIn;
+            }
         } else {
             feeAmount = FullMath.mulDivRoundingUp(amountIn, feePips, 1e6 - feePips);
         }

--- a/contracts/libraries/TickBitmap.sol
+++ b/contracts/libraries/TickBitmap.sol
@@ -46,7 +46,11 @@ library TickBitmap {
         bool lte
     ) internal view returns (int24 next, bool initialized) {
         int24 compressed = tick / tickSpacing;
-        if (tick < 0 && tick % tickSpacing != 0) compressed--; // round towards negative infinity
+        if (tick < 0) {
+            if (tick % tickSpacing != 0) {
+                compressed--; // round towards negative infinity
+            }
+        }
 
         if (lte) {
             (int16 wordPos, uint8 bitPos) = position(compressed);


### PR DESCRIPTION
Replaced "if (A && B) {}" with "if (A) {if (B) {} }" in mentioned six cases