### PR TITLE
Fix the `observationCardinalityNext` doc string in IUniswapV3PoolState.sol 

### DIFF
--- a/contracts/interfaces/pool/IUniswapV3PoolState.sol
+++ b/contracts/interfaces/pool/IUniswapV3PoolState.sol
@@ -13,7 +13,7 @@ interface IUniswapV3PoolState {
     /// boundary.
     /// observationIndex The index of the last oracle observation that was written,
     /// observationCardinality The current maximum number of observations stored in the pool,
-    /// observationCardinalityNext The next maximum number of observations, to be updated when the observation.
+    /// observationCardinalityNext The next maximum number of observations, updated when the current maximum is reached.
     /// feeProtocol The protocol fee for both tokens of the pool.
     /// Encoded as two 4 bit values, where the protocol fee of token1 is shifted 4 bits and the protocol fee of token0
     /// is the lower 4 bits. Used as the denominator of a fraction of the swap fee, e.g. 4 means 1/4th of the swap fee.


### PR DESCRIPTION
The previous docstring seemed to be an incomplete sentence