### PR TITLE
Fix Typographical Error in bug-bounty.md

### DIFF
--- a/bug-bounty.md
+++ b/bug-bounty.md
@@ -43,7 +43,7 @@ Rewards will be allocated based on the severity of the bug disclosed and will be
 
 Any vulnerability or bug discovered must be reported only to the following email: [security@uniswap.org](mailto:security@uniswap.org).
 
-The vulnerability must not be disclosed publicly or to any other person, entity or email address before Uniswap Labs has been notified, has fixed the issue, and has granted permission for public disclosure. In addition, disclosure must be made within 24 hours following discovery of the vulnerability.
+The vulnerability must not be disclosed publicly or to any other person, entity or email address before Uniswap Labs has been notified, has fixed the issue, and has granted permission for public disclosure. In addition, disclosure must be made within 24-hours following discovery of the vulnerability.
 
 A detailed report of a vulnerability increases the likelihood of a reward and may increase the reward amount. Please provide as much information about the vulnerability as possible, including:
 


### PR DESCRIPTION
This PR corrects a minor typographical error in the `bug-bounty.md` file:  

- Added a hyphen to "24-hours" for consistency and grammatical accuracy.

The update ensures the document maintains a professional and polished tone.  

### Notes  
Please review the change for alignment with documentation standards.
