### PR TITLE
docs: fix parameter comment in CollectProtocol event

### DIFF
--- a/contracts/interfaces/pool/IUniswapV3PoolEvents.sol
+++ b/contracts/interfaces/pool/IUniswapV3PoolEvents.sol
@@ -116,6 +116,6 @@ interface IUniswapV3PoolEvents {
     /// @param sender The address that collects the protocol fees
     /// @param recipient The address that receives the collected protocol fees
     /// @param amount0 The amount of token0 protocol fees that is withdrawn
-    /// @param amount0 The amount of token1 protocol fees that is withdrawn
+    /// @param amount1 The amount of token1 protocol fees that is withdrawn
     event CollectProtocol(address indexed sender, address indexed recipient, uint128 amount0, uint128 amount1);
 }


### PR DESCRIPTION
## Description
Fix incorrect parameter documentation in `IUniswapV3PoolEvents.sol`. The `@param amount0` was duplicated instead of using `@param amount1` for the second parameter.

## Changes
- Fix parameter documentation in `CollectProtocol` event to correctly document `amount1` parameter instead of duplicating `amount0`

## Before
/// @param amount0 The amount of token0 protocol fees that is withdrawn
/// @param amount0 The amount of token1 protocol fees that is withdrawn
## After
/// @param amount0 The amount of token0 protocol fees that is withdrawn
/// @param amount1 The amount of token1 protocol fees that is withdrawn

## Type of change
Documentation update (non-breaking change)

## Checklist
- [x] Documentation update only
- [x] No code changes
- [x] No breaking changes