### PR TITLE
docs: improve slot0 function return value documentation

### DIFF
--- a/contracts/interfaces/pool/IUniswapV3PoolState.sol
+++ b/contracts/interfaces/pool/IUniswapV3PoolState.sol
@@ -8,16 +8,16 @@ interface IUniswapV3PoolState {
     /// @notice The 0th storage slot in the pool stores many values, and is exposed as a single method to save gas
     /// when accessed externally.
     /// @return sqrtPriceX96 The current price of the pool as a sqrt(token1/token0) Q64.96 value
-    /// tick The current tick of the pool, i.e. according to the last tick transition that was run.
+    /// @return tick The current tick of the pool, i.e. according to the last tick transition that was run.
     /// This value may not always be equal to SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96) if the price is on a tick
     /// boundary.
-    /// observationIndex The index of the last oracle observation that was written,
-    /// observationCardinality The current maximum number of observations stored in the pool,
-    /// observationCardinalityNext The next maximum number of observations, to be updated when the observation.
-    /// feeProtocol The protocol fee for both tokens of the pool.
-    /// Encoded as two 4 bit values, where the protocol fee of token1 is shifted 4 bits and the protocol fee of token0
-    /// is the lower 4 bits. Used as the denominator of a fraction of the swap fee, e.g. 4 means 1/4th of the swap fee.
-    /// unlocked Whether the pool is currently locked to reentrancy
+    /// @return observationIndex The index of the last oracle observation that was written
+    /// @return observationCardinality The current maximum number of observations stored in the pool
+    /// @return observationCardinalityNext The next maximum number of observations, to be updated when the observation
+    /// @return feeProtocol The protocol fee for both tokens of the pool. Encoded as two 4 bit values, where the protocol fee of token1 
+    /// is shifted 4 bits and the protocol fee of token0 is the lower 4 bits. Used as the denominator of a fraction of the swap fee, 
+    /// e.g. 4 means 1/4th of the swap fee.
+    /// @return unlocked Whether the pool is currently locked to reentrancy
     function slot0()
         external
         view


### PR DESCRIPTION
## Description
Improve the documentation format for the `slot0()` function in `IUniswapV3PoolState.sol`. Add proper `@return` tags for all return values to maintain consistent documentation style.

## Changes
- Add `@return` tags for all return parameters in `slot0()` function
- Maintain detailed descriptions while improving readability
- Keep consistent documentation format across the interface

## Before
/// @return sqrtPriceX96 The current price of the pool as a sqrt(token1/token0) Q64.96 value
/// tick The current tick of the pool, i.e. according to the last tick transition that was run.
/// This value may not always be equal to SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96) if the price is on a tick
/// boundary.
/// observationIndex The index of the last oracle observation that was written,
/// observationCardinality The current maximum number of observations stored in the pool,
/// observationCardinalityNext The next maximum number of observations, to be updated when the observation.
/// feeProtocol The protocol fee for both tokens of the pool.
/// Encoded as two 4 bit values, where the protocol fee of token1 is shifted 4 bits and the protocol fee of token0
/// is the lower 4 bits. Used as the denominator of a fraction of the swap fee, e.g. 4 means 1/4th of the swap fee.
/// unlocked Whether the pool is currently locked to reentrancy

## After
/// @return sqrtPriceX96 The current price of the pool as a sqrt(token1/token0) Q64.96 value
/// @return tick The current tick of the pool, i.e. according to the last tick transition that was run.
/// This value may not always be equal to SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96) if the price is on a tick boundary.
/// @return observationIndex The index of the last oracle observation that was written
/// @return observationCardinality The current maximum number of observations stored in the pool
/// @return observationCardinalityNext The next maximum number of observations, to be updated when the observation
/// @return feeProtocol The protocol fee for both tokens of the pool. Encoded as two 4 bit values, where the protocol fee of token1
/// is shifted 4 bits and the protocol fee of token0 is the lower 4 bits. Used as the denominator of a fraction of the swap fee,
/// e.g. 4 means 1/4th of the swap fee.
/// @return unlocked Whether the pool is currently locked to reentrancy
## Type of change
Documentation update (non-breaking change)

## Checklist
- [x] Documentation update only
- [x] No code changes
- [x] No breaking changes
- [x] Maintains all technical details while improving format