### PR TITLE
allow compiler >=0.8.0

### DIFF
--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.0 <0.8.0;
+pragma solidity >=0.4.0;
 
 /// @title Contains 512-bit math functions
 /// @notice Facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision
@@ -61,7 +61,7 @@ library FullMath {
         // Factor powers of two out of denominator
         // Compute largest power of two divisor of denominator.
         // Always >= 1.
-        uint256 twos = -denominator & denominator;
+        uint256 twos = denominator & (~denominator + 1);
         // Divide denominator by power of two
         assembly {
             denominator := div(denominator, twos)


### PR DESCRIPTION
This PR updates the computation of the largest power of two divisor of the denominator in the mulDiv function. It replaces:
```solidity
uint256 twos = -denominator & denominator;
```
with
```solidity
uint256 twos = denominator & (~denominator + 1);
```
The new expression is equivalent to the original but uses an explicit two's complement computation, improving code clarity and readability.

All tests pass, and the change does not alter the functionality of the code.
Also allows the compilation for compilers above 0.8.0