### PR TITLE
fix comment of `computeSwapStep`

### DIFF
--- a/contracts/libraries/SwapMath.sol
+++ b/contracts/libraries/SwapMath.sol
@@ -5,7 +5,7 @@ import './FullMath.sol';
 import './SqrtPriceMath.sol';
 
 /// @title Computes the result of a swap within ticks
-/// @notice Contains methods for computing the result of a swap within a single tick price range, i.e., a single tick.
+/// @notice Contains methods for computing the result of a swap within a tick boundary.
 library SwapMath {
     /// @notice Computes the result of swapping some amount in, or amount out, given the parameters of the swap
     /// @dev The fee, plus the amount in, will never exceed the amount remaining if the swap's `amountSpecified` is positive


### PR DESCRIPTION
`computeSwapStep` doesn't necessarily compute result of a swap within a single tick, instead should be within a tick boundary.

As `sqrtRatioTargetX96` may be the price of the next initialized tick(LP liquidity boundary), which may be well beyond a single tick.

`computeSwapStep` only cares about boundary because liquidity only changes across a boundary, or say, the liquidity doesn't change for intermediate ticks.