### PR TITLE
fix: resolve TypeScript type error in BitMath.spec.ts

### DIFF
--- a/test/BitMath.spec.ts
+++ b/test/BitMath.spec.ts
@@ -9,7 +9,7 @@ describe('BitMath', () => {
   let bitMath: BitMathTest
   const fixture = async () => {
     const factory = await ethers.getContractFactory('BitMathTest')
-    return (await factory.deploy()) as BitMathTest
+    return (await factory.deploy()) as unknown as BitMathTest
   }
   beforeEach('deploy BitMathTest', async () => {
     bitMath = await waffle.loadFixture(fixture)


### PR DESCRIPTION
## What
Fixed TypeScript type error in BitMath.spec.ts

## Why
The issue was a type mismatch where `factory.deploy()` returns `Contract` type but the test expected `BitMathTest` type.

## Changes
- Added `as unknown as` type assertion to safely cast the deployed contract

## Testing
- The test now compiles successfully
- All BitMath tests should pass

Fixes #614
