### PR TITLE
ci: harden lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   run-linters:
     name: Run linters
@@ -21,12 +24,11 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Run linters
         uses: wearerequired/lint-action@a8497ddb33fb1205941fd40452ca9fff07e0770d
         with:
-          github_token: ${{ secrets.github_token }}
           prettier: true
-          auto_fix: true
+          auto_fix: false
           prettier_extensions: 'css,html,js,json,jsx,md,sass,scss,ts,tsx,vue,yaml,yml,sol'


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/lint.yml` against the `postinstall` → `GITHUB_TOKEN` → commit-injection class of CI supply-chain risk.

Three changes:

- **`permissions: contents: read`** at the workflow level. The job no longer needs a write-capable `GITHUB_TOKEN`; restricting scope is defense-in-depth per [GitHub's hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).
- **`yarn install --frozen-lockfile --ignore-scripts`**. `--frozen-lockfile` only prevents lockfile mutation; lifecycle scripts (`preinstall`/`install`/`postinstall`) still execute. `--ignore-scripts` disables them, so a poisoned dependency in a PR's `yarn.lock` cannot run arbitrary code on the runner.
- **`auto_fix: false`** for `wearerequired/lint-action` and removal of `github_token`. Lint violations are reported, not auto-pushed. Without `auto_fix`, the action does not need a token, and the runner no longer holds a write credential a malicious step could exfiltrate.

## Why

Today, `pull_request` events from same-repo branches run with a write-capable `GITHUB_TOKEN`. Combined with `yarn install` (lifecycle scripts on) and `auto_fix: true` (token-authored pushes enabled), there is a usable path from "open a PR that modifies `yarn.lock`" to "push commits via the workflow's token." This PR closes that path without changing what the linter actually verifies.

Behavior preserved:
- Prettier still runs over the same file extensions.
- Failing lint still fails the check on PRs and on \`push\` to \`main\`.
- No change to required status checks, branch protection, or any other workflow.

Behavior removed:
- Workflow can no longer push commits to PR branches. Contributors will fix lint issues locally, as is the GitHub-recommended pattern.

## Test plan

- [ ] Lint job runs successfully on this PR (CI green).
- [ ] Confirm that intentional Prettier violations would still fail the check (sanity-check the action still flags issues; just doesn't auto-fix them).
- [ ] No other workflow depends on \`lint.yml\` writing to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)