### PR TITLE
docs: note position rounding behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ repository.
 
 This repository is subject to the Uniswap V3 bug bounty program, per the terms defined [here](./bug-bounty.md).
 
+## Precision and rounding
+
+Uniswap v3 core contracts use integer math. Position updates that call `modifyPosition`,
+such as minting, burning, increasing liquidity, or decreasing liquidity, can round down
+by less than 1 wei of fees or token amounts. Integrations should account for this
+possible dust when displaying or reconciling positions, including when a user requests
+to remove 100% of a position.
+
 ## Local deployment
 
 In order to deploy this code to a local testnet, you should install the npm package


### PR DESCRIPTION
## Summary
- Add a README note documenting integer-math rounding/dust behavior for position updates.
- Call out that integrations should account for possible less-than-1-wei differences when reconciling or displaying positions, including 100% removal flows.

Closes #570
References #424

## Test Plan
- `npx --yes prettier@2.0.5 --check README.md`
- `git diff --check`
