### PR TITLE
docs: document update position return value

### DIFF
--- a/contracts/UniswapV3Pool.sol
+++ b/contracts/UniswapV3Pool.sol
@@ -375,7 +375,9 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
     /// @param owner the owner of the position
     /// @param tickLower the lower tick of the position's tick range
     /// @param tickUpper the upper tick of the position's tick range
+    /// @param liquidityDelta the change in position liquidity
     /// @param tick the current tick, passed to avoid sloads
+    /// @return position a storage pointer to the updated position
     function _updatePosition(
         address owner,
         int24 tickLower,


### PR DESCRIPTION
## Summary
- Adds NatSpec for `_updatePosition`'s returned storage position pointer.
- Documents the existing `liquidityDelta` parameter while updating the same NatSpec block.

Closes #584

## Test Plan
- `npx --yes --package prettier@2.0.5 --package prettier-plugin-solidity@1.0.0-alpha.59 prettier --check contracts/UniswapV3Pool.sol` (existing baseline formatting mismatch also occurs on the HEAD version of this file)
- `git diff --check`
