### PR TITLE
ci: fix Lint workflow broken since #1091

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   run-linters:
@@ -29,6 +30,7 @@ jobs:
       - name: Run linters
         uses: wearerequired/lint-action@a8497ddb33fb1205941fd40452ca9fff07e0770d
         with:
+          github_token: ${{ secrets.github_token }}
           prettier: true
           auto_fix: false
           prettier_extensions: 'css,html,js,json,jsx,md,sass,scss,ts,tsx,vue,yaml,yml,sol'


### PR DESCRIPTION
## Summary

The Lint workflow has been failing on every run since #1091 merged on 2026-04-30, including on `push` to `main`. This restores it without giving back the write capability that #1091 correctly removed.

Two changes:

- **`checks: write`** added to the `permissions` block.
- **`github_token`** restored as an input to `wearerequired/lint-action`.

## Why it broke

`lint-action` creates a GitHub check run through the API on every invocation — not only when `auto_fix` is enabled. #1091 removed `github_token` on the reasonable assumption that `auto_fix: false` made it unnecessary, so that API call now runs unauthenticated:

```
data: '{ "message": "Bad credentials", "status": "401" }'
Error: Error trying to create GitHub check for Prettier: Received status code 401
Error: Exiting because of unhandled promise rejection
```

The job then exits non-zero regardless of whether Prettier found anything.

## Why this is still hardened

The commit-injection path #1091 closed stays closed, by three independent mechanisms:

- `contents: read` — the token cannot push, so there is no commit path even with a token present.
- `--ignore-scripts` — dependency lifecycle scripts do not execute, so a poisoned dependency has no way to run and reach the token.
- `auto_fix: false` — the action does not attempt to push.

`checks: write` grants only the ability to create check runs.

## Verification

This configuration is confirmed working in Uniswap/v3-periphery#472, where the identical change took the job from the 401 above to a passing `Run linters` **and** a successful `Prettier` check run — the exact API call that was failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)